### PR TITLE
chore(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753216019,
-        "narHash": "sha256-zik7WISrR1ks2l6T1MZqZHb/OqroHdJnSnAehkE0kCk=",
+        "lastModified": 1755946532,
+        "narHash": "sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l+bIxdT5gc=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "be166e11d86ba4186db93e10c54a141058bdce49",
+        "rev": "81584dae2df6ac79f6b6dae0ecb7705e95129ada",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1755921820,
-        "narHash": "sha256-xTRXoaGtuIi4VvJNGuHC8DPHnEIJUqVtt7kqU8MdXes=",
+        "lastModified": 1756526623,
+        "narHash": "sha256-G8N9zjlLZyI/BkrlI/fSrP0Zif/ttr3JWq1m5VxTLR4=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "c43149f02063de9b0d75c2b45f54631bd82667b2",
+        "rev": "702be0c726c76de3e069ae95c7b1dab5bd568000",
         "type": "gitlab"
       },
       "original": {
@@ -324,11 +324,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754420989,
-        "narHash": "sha256-3e4wHzNwTMg7GaeLH9A091DMaO9AfFxUjpfqbddCUeo=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7f38f25a44023a21a504bd3fd9d4f41c4a39f55c",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755914636,
-        "narHash": "sha256-VJ+Gm6YsHlPfUCpmRQxvdiZW7H3YPSrdVOewQHAhZN8=",
+        "lastModified": 1756496801,
+        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b55a6ac58b678199e5bba701aaff69e2b3281c0",
+        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
         "type": "github"
       },
       "original": {
@@ -734,11 +734,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754305013,
-        "narHash": "sha256-u+M2f0Xf1lVHzIPQ7DsNCDkM1NYxykOSsRr4t3TbSM4=",
+        "lastModified": 1755678602,
+        "narHash": "sha256-uEC5O/NIUNs1zmc1aH1+G3GRACbODjk2iS0ET5hXtuk=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "4c1d63a0f22135db123fc789f174b89544c6ec2d",
+        "rev": "157cc52065a104fc3b8fa542ae648b992421d1c7",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1755945900,
-        "narHash": "sha256-OIuSFzAbKHfRZtxrYP4CZRKGAhlAHEjY5G0Q7ZfeH7w=",
+        "lastModified": 1756498600,
+        "narHash": "sha256-09FSU9GTVyDlTcXjsjzumfUkIJUwht1DESNh41kufdc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d9cf1cb78ef3dfd82f03965aab70792bbe25c9e2",
+        "rev": "ea42041f936d5810c5cfa45d6bece12dde2fd9b6",
         "type": "github"
       },
       "original": {
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755183521,
-        "narHash": "sha256-wrP8TM2lb2x0+PyTc7Uc3yfVBeIlYW7+hFeG14N9Cr8=",
+        "lastModified": 1756461489,
+        "narHash": "sha256-MeRYPD6GTbBEcoEqwl8kqCSKtM8CJcYayvPfKGoQkzc=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "c1ddebb423acc7c88653c04de5ddafee64dac89a",
+        "rev": "376d08bbbd861f2125f5ef86e0003e3636ce110f",
         "type": "github"
       },
       "original": {
@@ -941,11 +941,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754481650,
-        "narHash": "sha256-6u6HdEFJh5gY6VfyMQbhP7zDdVcqOrCDTkbiHJmAtMI=",
+        "lastModified": 1756117388,
+        "narHash": "sha256-oRDel6pNl/T2tI+nc/USU9ZP9w08dxtl7hiZxa0C/Wc=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "df6b8820c4a0835d83d0c7c7be86fbc555f1f7fd",
+        "rev": "b2ae3204845f5f2f79b4703b441252d8ad2ecfd0",
         "type": "github"
       },
       "original": {
@@ -966,11 +966,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751897909,
-        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
+        "lastModified": 1755184602,
+        "narHash": "sha256-RCBQN8xuADB0LEgaKbfRqwm6CdyopE1xIEhNc67FAbw=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
+        "rev": "b3b0f1f40ae09d4447c20608e5a4faf8bf3c492d",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1002,11 @@
     "import-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1752528124,
-        "narHash": "sha256-hrZX5Zq6N5b/K7QTc/SSMzRpz8eKpLMdWSQ/5sJ4+u8=",
+        "lastModified": 1756213516,
+        "narHash": "sha256-SS8ajV9oLQWNP+0mZySc3sBEy3Mu5iSCxwPZzuimydk=",
         "owner": "piersolenski",
         "repo": "import.nvim",
-        "rev": "c2af4568c6aaa9521ccb4eb86c6aa9afc2245890",
+        "rev": "a933f0885395f3735e4b15cfde7f4c1b6d04d79f",
         "type": "github"
       },
       "original": {
@@ -1018,11 +1018,11 @@
     "kulala-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1754205606,
-        "narHash": "sha256-yep53+rNtL3f1e+UPyQtqWXq9fYHu/yOA04X3AIHlCU=",
+        "lastModified": 1756210457,
+        "narHash": "sha256-N0OMhs/2LK3NR1iFS3z/WsDawVcbqof/EWLyzg404xY=",
         "owner": "mistweaverco",
         "repo": "kulala.nvim",
-        "rev": "65d102f65cfee9f338ba8a0bd43187a7cac898e9",
+        "rev": "cfe40c33636ab0f53f1edd3dbda37f4298298797",
         "type": "github"
       },
       "original": {
@@ -1037,14 +1037,15 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_2"
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1755929511,
-        "narHash": "sha256-CJw0fekEGdN6SnOrOR3ubmyj6wVMrbyQNEYtUuJ/CbE=",
+        "lastModified": 1756057867,
+        "narHash": "sha256-ziR5eQGqRWhW8tf8r0TIplaqNt+HXu1G1X41LUr4IYo=",
         "owner": "hraban",
         "repo": "mac-app-util",
-        "rev": "6ee41d9f6b7e326c681e6d9700f579dbae00fecb",
+        "rev": "8414fa1e2cb775b17793104a9095aabeeada63ef",
         "type": "github"
       },
       "original": {
@@ -1097,8 +1098,8 @@
         "git-hooks": "git-hooks",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
-        "nixpkgs": "nixpkgs_3",
-        "treefmt-nix": "treefmt-nix"
+        "nixpkgs": "nixpkgs_4",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1756193366,
@@ -1200,11 +1201,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1756469547,
+        "narHash": "sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "41d292bfc37309790f70f4c120b79280ce40af16",
         "type": "github"
       },
       "original": {
@@ -1216,11 +1217,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {
@@ -1230,7 +1247,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1756128520,
         "narHash": "sha256-R94HxJBi+RK1iCm8Y4Q9pdrHZl0GZoDPIaYwjxRNPh4=",
@@ -1246,13 +1263,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {
@@ -1262,7 +1279,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -1290,11 +1307,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1754388740,
-        "narHash": "sha256-6++6FDc/hcMpaJPgOrGzwmzCSgix3zIlcuTIy9+aNSs=",
+        "lastModified": 1755463179,
+        "narHash": "sha256-5Ggb1Mhf7ZlRgGi2puCa2PvWs6KbMnWBlW6KW7Vf79Y=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "22fb0d22cc474e85f94c5aa95b6c550c81ca7278",
+        "rev": "03833118267ad32226b014b360692bdce9d6e082",
         "type": "github"
       },
       "original": {
@@ -1313,17 +1330,17 @@
         "import-nvim": "import-nvim",
         "kulala-nvim": "kulala-nvim",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nvf": "nvf",
         "root-nvim": "root-nvim",
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1756237064,
-        "narHash": "sha256-nAe5bkCkdFBxq9LdFELKZBHMk2/TpaOssM0szhiiR9c=",
+        "lastModified": 1756252278,
+        "narHash": "sha256-uIP0+bUJYPO5Solu0njsMXs+lKmNioD1YEE2eLr7S6I=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "ebd00fa1c12b06561c0b22a3467c85e0a67830fd",
+        "rev": "697c681f2328ce7a91bf8e86d28d41ef409b636b",
         "type": "github"
       },
       "original": {
@@ -1342,11 +1359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754416808,
-        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -1368,7 +1385,7 @@
         "mac-app-util": "mac-app-util",
         "nix-flatpak": "nix-flatpak",
         "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable",
         "nvim-config": "nvim-config",
         "rust-system-scripts": "rust-system-scripts",
@@ -1398,7 +1415,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1752720268,
@@ -1672,6 +1689,24 @@
     },
     "treefmt-nix": {
       "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1755934250,
+        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
         "nixpkgs": [
           "nvim-config",
           "neovim-nightly-overlay",
@@ -1720,11 +1755,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753633878,
-        "narHash": "sha256-js2sLRtsOUA/aT10OCDaTjO80yplqwOIaLUqEe0nMx0=",
+        "lastModified": 1755354946,
+        "narHash": "sha256-zdov5f/GcoLQc9qYIS1dUTqtJMeDqmBmo59PAxze6e4=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "371b96bd11ad2006ed4f21229dbd1be69bed3e8a",
+        "rev": "a10726d6a8d0ef1a0c645378f983b6278c42eaa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/c43149f02063de9b0d75c2b45f54631bd82667b2?dir=pkgs/firefox-addons&narHash=sha256-xTRXoaGtuIi4VvJNGuHC8DPHnEIJUqVtt7kqU8MdXes%3D' (2025-08-23)
  → 'gitlab:rycee/nur-expressions/702be0c726c76de3e069ae95c7b1dab5bd568000?dir=pkgs/firefox-addons&narHash=sha256-G8N9zjlLZyI/BkrlI/fSrP0Zif/ttr3JWq1m5VxTLR4%3D' (2025-08-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8b55a6ac58b678199e5bba701aaff69e2b3281c0?narHash=sha256-VJ%2BGm6YsHlPfUCpmRQxvdiZW7H3YPSrdVOewQHAhZN8%3D' (2025-08-23)
  → 'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb?narHash=sha256-IYIsnPy%2BcJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8%3D' (2025-08-29)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/d9cf1cb78ef3dfd82f03965aab70792bbe25c9e2?narHash=sha256-OIuSFzAbKHfRZtxrYP4CZRKGAhlAHEjY5G0Q7ZfeH7w%3D' (2025-08-23)
  → 'github:hyprwm/Hyprland/ea42041f936d5810c5cfa45d6bece12dde2fd9b6?narHash=sha256-09FSU9GTVyDlTcXjsjzumfUkIJUwht1DESNh41kufdc%3D' (2025-08-29)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/be166e11d86ba4186db93e10c54a141058bdce49?narHash=sha256-zik7WISrR1ks2l6T1MZqZHb/OqroHdJnSnAehkE0kCk%3D' (2025-07-22)
  → 'github:hyprwm/aquamarine/81584dae2df6ac79f6b6dae0ecb7705e95129ada?narHash=sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l%2BbIxdT5gc%3D' (2025-08-23)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/4c1d63a0f22135db123fc789f174b89544c6ec2d?narHash=sha256-u%2BM2f0Xf1lVHzIPQ7DsNCDkM1NYxykOSsRr4t3TbSM4%3D' (2025-08-04)
  → 'github:hyprwm/hyprgraphics/157cc52065a104fc3b8fa542ae648b992421d1c7?narHash=sha256-uEC5O/NIUNs1zmc1aH1%2BG3GRACbODjk2iS0ET5hXtuk%3D' (2025-08-20)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/df6b8820c4a0835d83d0c7c7be86fbc555f1f7fd?narHash=sha256-6u6HdEFJh5gY6VfyMQbhP7zDdVcqOrCDTkbiHJmAtMI%3D' (2025-08-06)
  → 'github:hyprwm/hyprutils/b2ae3204845f5f2f79b4703b441252d8ad2ecfd0?narHash=sha256-oRDel6pNl/T2tI%2Bnc/USU9ZP9w08dxtl7hiZxa0C/Wc%3D' (2025-08-25)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/fcca0c61f988a9d092cbb33e906775014c61579d?narHash=sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao%3D' (2025-07-07)
  → 'github:hyprwm/hyprwayland-scanner/b3b0f1f40ae09d4447c20608e5a4faf8bf3c492d?narHash=sha256-RCBQN8xuADB0LEgaKbfRqwm6CdyopE1xIEhNc67FAbw%3D' (2025-08-14)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/9c52372878df6911f9afc1e2a1391f55e4dfc864?narHash=sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef%2B6fRcofA%3D' (2025-08-05)
  → 'github:cachix/git-hooks.nix/e891a93b193fcaf2fc8012d890dc7f0befe86ec2?narHash=sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs%3D' (2025-08-23)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/371b96bd11ad2006ed4f21229dbd1be69bed3e8a?narHash=sha256-js2sLRtsOUA/aT10OCDaTjO80yplqwOIaLUqEe0nMx0%3D' (2025-07-27)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/a10726d6a8d0ef1a0c645378f983b6278c42eaa0?narHash=sha256-zdov5f/GcoLQc9qYIS1dUTqtJMeDqmBmo59PAxze6e4%3D' (2025-08-16)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/c1ddebb423acc7c88653c04de5ddafee64dac89a?narHash=sha256-wrP8TM2lb2x0%2BPyTc7Uc3yfVBeIlYW7%2BhFeG14N9Cr8%3D' (2025-08-14)
  → 'github:hyprwm/hyprland-plugins/376d08bbbd861f2125f5ef86e0003e3636ce110f?narHash=sha256-MeRYPD6GTbBEcoEqwl8kqCSKtM8CJcYayvPfKGoQkzc%3D' (2025-08-29)
• Updated input 'mac-app-util':
    'github:hraban/mac-app-util/6ee41d9f6b7e326c681e6d9700f579dbae00fecb?narHash=sha256-CJw0fekEGdN6SnOrOR3ubmyj6wVMrbyQNEYtUuJ/CbE%3D' (2025-08-23)
  → 'github:hraban/mac-app-util/8414fa1e2cb775b17793104a9095aabeeada63ef?narHash=sha256-ziR5eQGqRWhW8tf8r0TIplaqNt%2BHXu1G1X41LUr4IYo%3D' (2025-08-24)
• Added input 'mac-app-util/treefmt-nix':
    'github:numtide/treefmt-nix/74e1a52d5bd9430312f8d1b8b0354c92c17453e5?narHash=sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU%3D' (2025-08-23)
• Added input 'mac-app-util/treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/cab778239e705082fe97bb4990e0d24c50924c04?narHash=sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU%3D' (2025-08-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/20075955deac2583bb12f07151c2df830ef346b4?narHash=sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs%2BStOp19xNsbqdOg%3D' (2025-08-19)
  → 'github:NixOS/nixpkgs/dfb2f12e899db4876308eba6d93455ab7da304cd?narHash=sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE%3D' (2025-08-28)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/9cb344e96d5b6918e94e1bca2d9f3ea1e9615545?narHash=sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A%3D' (2025-08-20)
  → 'github:NixOS/nixpkgs/41d292bfc37309790f70f4c120b79280ce40af16?narHash=sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k%3D' (2025-08-29)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/ebd00fa1c12b06561c0b22a3467c85e0a67830fd?narHash=sha256-nAe5bkCkdFBxq9LdFELKZBHMk2/TpaOssM0szhiiR9c%3D' (2025-08-26)
  → 'github:derethil/nvim-config/697c681f2328ce7a91bf8e86d28d41ef409b636b?narHash=sha256-uIP0%2BbUJYPO5Solu0njsMXs%2BlKmNioD1YEE2eLr7S6I%3D' (2025-08-26)
• Updated input 'nvim-config/flake-parts':
    'github:hercules-ci/flake-parts/7f38f25a44023a21a504bd3fd9d4f41c4a39f55c?narHash=sha256-3e4wHzNwTMg7GaeLH9A091DMaO9AfFxUjpfqbddCUeo%3D' (2025-08-05)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)
• Updated input 'nvim-config/import-nvim':
    'github:piersolenski/import.nvim/c2af4568c6aaa9521ccb4eb86c6aa9afc2245890?narHash=sha256-hrZX5Zq6N5b/K7QTc/SSMzRpz8eKpLMdWSQ/5sJ4%2Bu8%3D' (2025-07-14)
  → 'github:piersolenski/import.nvim/a933f0885395f3735e4b15cfde7f4c1b6d04d79f?narHash=sha256-SS8ajV9oLQWNP%2B0mZySc3sBEy3Mu5iSCxwPZzuimydk%3D' (2025-08-26)
• Updated input 'nvim-config/kulala-nvim':
    'github:mistweaverco/kulala.nvim/65d102f65cfee9f338ba8a0bd43187a7cac898e9?narHash=sha256-yep53%2BrNtL3f1e%2BUPyQtqWXq9fYHu/yOA04X3AIHlCU%3D' (2025-08-03)
  → 'github:mistweaverco/kulala.nvim/cfe40c33636ab0f53f1edd3dbda37f4298298797?narHash=sha256-N0OMhs/2LK3NR1iFS3z/WsDawVcbqof/EWLyzg404xY%3D' (2025-08-26)
• Updated input 'nvim-config/nixpkgs':
    'github:NixOS/nixpkgs/5b09dc45f24cf32316283e62aec81ffee3c3e376?narHash=sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY%3D' (2025-08-03)
  → 'github:NixOS/nixpkgs/3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5?narHash=sha256-XexyKZpf46cMiO5Vbj%2BdWSAXOnr285GHsMch8FBoHbc%3D' (2025-08-25)
• Updated input 'nvim-config/nvf':
    'github:notashelf/nvf/22fb0d22cc474e85f94c5aa95b6c550c81ca7278?narHash=sha256-6%2B%2B6FDc/hcMpaJPgOrGzwmzCSgix3zIlcuTIy9%2BaNSs%3D' (2025-08-05)
  → 'github:notashelf/nvf/03833118267ad32226b014b360692bdce9d6e082?narHash=sha256-5Ggb1Mhf7ZlRgGi2puCa2PvWs6KbMnWBlW6KW7Vf79Y%3D' (2025-08-17)
• Updated input 'nvim-config/nvf/flake-parts':
    'github:hercules-ci/flake-parts/644e0fc48951a860279da645ba77fe4a6e814c5e?narHash=sha256-TVcTNvOeWWk1DXljFxVRp%2BE0tzG1LhrVjOGGoMHuXio%3D' (2025-07-21)
  → 'github:hercules-ci/flake-parts/af66ad14b28a127c5c0f3bbb298218fc63528a18?narHash=sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8%3D' (2025-08-06)```