### PR TITLE
chore(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755825449,
-        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
+        "lastModified": 1757130842,
+        "narHash": "sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
+        "rev": "15f067638e2887c58c4b6ba1bdb65a0b61dc58c5",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1756526623,
-        "narHash": "sha256-G8N9zjlLZyI/BkrlI/fSrP0Zif/ttr3JWq1m5VxTLR4=",
+        "lastModified": 1757217813,
+        "narHash": "sha256-3YNafYamgO4Z/g8FthOLCfStCFc0KNJu3B/nAhDgrlI=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "702be0c726c76de3e069ae95c7b1dab5bd568000",
+        "rev": "f83a71ab5c6a1cbdefa07487e8e201b954aae435",
         "type": "gitlab"
       },
       "original": {
@@ -668,11 +668,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756496801,
-        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
+        "lastModified": 1757256385,
+        "narHash": "sha256-WK7tOhWwr15mipcckhDg2no/eSpM1nIh4C9le8HgHhk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
+        "rev": "f35703b412c67b48e97beb6e27a6ab96a084cd37",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1756498600,
-        "narHash": "sha256-09FSU9GTVyDlTcXjsjzumfUkIJUwht1DESNh41kufdc=",
+        "lastModified": 1757180583,
+        "narHash": "sha256-PcHIK+FlH9EiP59ikyTOr66wvdMvxCieW8UVKLLgA5c=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ea42041f936d5810c5cfa45d6bece12dde2fd9b6",
+        "rev": "bce43f74eb8e4570d0d043f5fc8257eef7a57399",
         "type": "github"
       },
       "original": {
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756461489,
-        "narHash": "sha256-MeRYPD6GTbBEcoEqwl8kqCSKtM8CJcYayvPfKGoQkzc=",
+        "lastModified": 1756806479,
+        "narHash": "sha256-+RLX4BmuMw4c97npsBcjjEuy+s83POX9Yp8Nkj499lA=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "376d08bbbd861f2125f5ef86e0003e3636ce110f",
+        "rev": "b8d6d369618078b2dbb043480ca65fe3521f273b",
         "type": "github"
       },
       "original": {
@@ -1217,11 +1217,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1756469547,
-        "narHash": "sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k=",
+        "lastModified": 1757020766,
+        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41d292bfc37309790f70f4c120b79280ce40af16",
+        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
         "type": "github"
       },
       "original": {
@@ -1249,11 +1249,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1756386758,
-        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -1353,11 +1353,11 @@
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1757111868,
-        "narHash": "sha256-wbNZqr6dBH4UQ0/S/8ITQPY8WjYItf4a5BcE3LMgqMA=",
+        "lastModified": 1757113720,
+        "narHash": "sha256-OSKKsTJKeB+5OArGp5iZbzYY40fdTKRDGi4m5oFan8M=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "2cb2bd8ae9a47831768d96c011916ef51108223a",
+        "rev": "94669d1a91c4ca73516164725d4960511942b721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'darwin':
    'github:LnL7/nix-darwin/8df64f819698c1fee0c2969696f54a843b2231e8?narHash=sha256-XkiN4NM9Xdy59h69Pc%2BVg4PxkSm9EWl6u7k6D5FZ5cM%3D' (2025-08-22)
  → 'github:LnL7/nix-darwin/15f067638e2887c58c4b6ba1bdb65a0b61dc58c5?narHash=sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA%3D' (2025-09-06)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/702be0c726c76de3e069ae95c7b1dab5bd568000?dir=pkgs/firefox-addons&narHash=sha256-G8N9zjlLZyI/BkrlI/fSrP0Zif/ttr3JWq1m5VxTLR4%3D' (2025-08-30)
  → 'gitlab:rycee/nur-expressions/102a040fa2e745daf670819aac53d1f6f73635af?dir=pkgs/firefox-addons&narHash=sha256-AlCnmivsXeZAiDz0b0n/HsYx6ccowNATAilNxLMFgeM%3D' (2025-09-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/77a71380c38fb2a440b4b5881bbc839f6230e1cb?narHash=sha256-IYIsnPy%2BcJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8%3D' (2025-08-29)
  → 'github:nix-community/home-manager/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf?narHash=sha256-a%2BNMGl5tcvm%2BhyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ%3D' (2025-09-05)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/ea42041f936d5810c5cfa45d6bece12dde2fd9b6?narHash=sha256-09FSU9GTVyDlTcXjsjzumfUkIJUwht1DESNh41kufdc%3D' (2025-08-29)
  → 'github:hyprwm/Hyprland/4e785d12a91117cd5b255052799d1a051d9976c0?narHash=sha256-Hz5S4fILpYd1smWDZ%2BuLYjHgW22v6JS/04j15I4cFZE%3D' (2025-09-04)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/376d08bbbd861f2125f5ef86e0003e3636ce110f?narHash=sha256-MeRYPD6GTbBEcoEqwl8kqCSKtM8CJcYayvPfKGoQkzc%3D' (2025-08-29)
  → 'github:hyprwm/hyprland-plugins/b8d6d369618078b2dbb043480ca65fe3521f273b?narHash=sha256-%2BRLX4BmuMw4c97npsBcjjEuy%2Bs83POX9Yp8Nkj499lA%3D' (2025-09-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/dfb2f12e899db4876308eba6d93455ab7da304cd?narHash=sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE%3D' (2025-08-28)
  → 'github:NixOS/nixpkgs/d0fc30899600b9b3466ddb260fd83deb486c32f1?narHash=sha256-rw/PHa1cqiePdBxhF66V7R%2BWAP8WekQ0mCDG4CFqT8Y%3D' (2025-09-02)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/41d292bfc37309790f70f4c120b79280ce40af16?narHash=sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k%3D' (2025-08-29)
  → 'github:NixOS/nixpkgs/fe83bbdde2ccdc2cb9573aa846abe8363f79a97a?narHash=sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0%3D' (2025-09-04)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/2cb2bd8ae9a47831768d96c011916ef51108223a?narHash=sha256-wbNZqr6dBH4UQ0/S/8ITQPY8WjYItf4a5BcE3LMgqMA%3D' (2025-09-05)
  → 'github:derethil/nvim-config/94669d1a91c4ca73516164725d4960511942b721?narHash=sha256-OSKKsTJKeB%2B5OArGp5iZbzYY40fdTKRDGi4m5oFan8M%3D' (2025-09-05)```