### PR TITLE
chore(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757130842,
-        "narHash": "sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA=",
+        "lastModified": 1757430124,
+        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "15f067638e2887c58c4b6ba1bdb65a0b61dc58c5",
+        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1757217813,
-        "narHash": "sha256-3YNafYamgO4Z/g8FthOLCfStCFc0KNJu3B/nAhDgrlI=",
+        "lastModified": 1757736223,
+        "narHash": "sha256-4yhWsAvejkPRNdx9eKAVOQt1t8vI6qF/kITCRSIIiK8=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "f83a71ab5c6a1cbdefa07487e8e201b954aae435",
+        "rev": "a73f8d6c29ea0e05c0dc570d4047e0aed1edd00d",
         "type": "gitlab"
       },
       "original": {
@@ -668,11 +668,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757256385,
-        "narHash": "sha256-WK7tOhWwr15mipcckhDg2no/eSpM1nIh4C9le8HgHhk=",
+        "lastModified": 1757698511,
+        "narHash": "sha256-UqHHGydF/q3jfYXCpvYLA0TWtvByOp1NwOKCUjhYmPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f35703b412c67b48e97beb6e27a6ab96a084cd37",
+        "rev": "a3fcc92180c7462082cd849498369591dfb20855",
         "type": "github"
       },
       "original": {
@@ -750,11 +750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755678602,
-        "narHash": "sha256-uEC5O/NIUNs1zmc1aH1+G3GRACbODjk2iS0ET5hXtuk=",
+        "lastModified": 1757542864,
+        "narHash": "sha256-8i9tsVoOmLQDHJkNgzJWnmxYFGkJNsSndimYpCoqmoA=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "157cc52065a104fc3b8fa542ae648b992421d1c7",
+        "rev": "aa9d14963b94186934fd0715d9a7f0f2719e64bb",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1757180583,
-        "narHash": "sha256-PcHIK+FlH9EiP59ikyTOr66wvdMvxCieW8UVKLLgA5c=",
+        "lastModified": 1757718690,
+        "narHash": "sha256-mX8PurO19mvSee1Ecs+w+WC8y4UaTdgCDpxk4fTXNQ4=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "bce43f74eb8e4570d0d043f5fc8257eef7a57399",
+        "rev": "adbf7c8663cfbc91fca78d3504fa8f73ce4bd23a",
         "type": "github"
       },
       "original": {
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756806479,
-        "narHash": "sha256-+RLX4BmuMw4c97npsBcjjEuy+s83POX9Yp8Nkj499lA=",
+        "lastModified": 1757721581,
+        "narHash": "sha256-tbNzBbtkTuoO89Pd0mETjLlZ1VSMCSEeAadOGu98PAA=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "b8d6d369618078b2dbb043480ca65fe3521f273b",
+        "rev": "27e1ad9042ebc01700fb56350e62a75a7da37a83",
         "type": "github"
       },
       "original": {
@@ -903,11 +903,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753819801,
-        "narHash": "sha256-tHe6XeNeVeKapkNM3tcjW4RuD+tB2iwwoogWJOtsqTI=",
+        "lastModified": 1757508108,
+        "narHash": "sha256-bTYedtQFqqVBAh42scgX7+S3O6XKLnT6FTC6rpmyCCc=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "b308a818b9dcaa7ab8ccab891c1b84ebde2152bc",
+        "rev": "119bcb9aa742658107b326c50dcd24ab59b309b7",
         "type": "github"
       },
       "original": {
@@ -932,11 +932,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753622892,
-        "narHash": "sha256-0K+A+gmOI8IklSg5It1nyRNv0kCNL51duwnhUO/B8JA=",
+        "lastModified": 1756810301,
+        "narHash": "sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "23f0debd2003f17bd65f851cd3f930cff8a8c809",
+        "rev": "3d63fb4a42c819f198deabd18c0c2c1ded1de931",
         "type": "github"
       },
       "original": {
@@ -1217,11 +1217,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1757020766,
-        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
+        "lastModified": 1757545623,
+        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
+        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
         "type": "github"
       },
       "original": {
@@ -1249,11 +1249,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -1353,11 +1353,11 @@
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1757446883,
-        "narHash": "sha256-E5vq21SSmmQY1w4Mj2xBr6u6Cdo7o7IOkcI4rWp4JDY=",
+        "lastModified": 1757698028,
+        "narHash": "sha256-FyLi+0HFI+TRBq76LFDhuKbvLpWa3F4WyQuXfRhOkDY=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "5467c9150dd1fc9f350f084419641f0f81b5074f",
+        "rev": "1a1e583f4ad2b0a955b67d62d02851725fc1f8ee",
         "type": "github"
       },
       "original": {
@@ -1376,11 +1376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1757588530,
+        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
         "type": "github"
       },
       "original": {
@@ -1532,11 +1532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754988908,
-        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
+        "lastModified": 1757503115,
+        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
+        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'darwin':
    'github:LnL7/nix-darwin/15f067638e2887c58c4b6ba1bdb65a0b61dc58c5?narHash=sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA%3D' (2025-09-06)
  → 'github:LnL7/nix-darwin/830b3f0b50045cf0bcfd4dab65fad05bf882e196?narHash=sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk%3D' (2025-09-09)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/f83a71ab5c6a1cbdefa07487e8e201b954aae435?dir=pkgs/firefox-addons&narHash=sha256-3YNafYamgO4Z/g8FthOLCfStCFc0KNJu3B/nAhDgrlI%3D' (2025-09-07)
  → 'gitlab:rycee/nur-expressions/a73f8d6c29ea0e05c0dc570d4047e0aed1edd00d?dir=pkgs/firefox-addons&narHash=sha256-4yhWsAvejkPRNdx9eKAVOQt1t8vI6qF/kITCRSIIiK8%3D' (2025-09-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f35703b412c67b48e97beb6e27a6ab96a084cd37?narHash=sha256-WK7tOhWwr15mipcckhDg2no/eSpM1nIh4C9le8HgHhk%3D' (2025-09-07)
  → 'github:nix-community/home-manager/a3fcc92180c7462082cd849498369591dfb20855?narHash=sha256-UqHHGydF/q3jfYXCpvYLA0TWtvByOp1NwOKCUjhYmPs%3D' (2025-09-12)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/bce43f74eb8e4570d0d043f5fc8257eef7a57399?narHash=sha256-PcHIK%2BFlH9EiP59ikyTOr66wvdMvxCieW8UVKLLgA5c%3D' (2025-09-06)
  → 'github:hyprwm/Hyprland/adbf7c8663cfbc91fca78d3504fa8f73ce4bd23a?narHash=sha256-mX8PurO19mvSee1Ecs%2Bw%2BWC8y4UaTdgCDpxk4fTXNQ4%3D' (2025-09-12)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/157cc52065a104fc3b8fa542ae648b992421d1c7?narHash=sha256-uEC5O/NIUNs1zmc1aH1%2BG3GRACbODjk2iS0ET5hXtuk%3D' (2025-08-20)
  → 'github:hyprwm/hyprgraphics/aa9d14963b94186934fd0715d9a7f0f2719e64bb?narHash=sha256-8i9tsVoOmLQDHJkNgzJWnmxYFGkJNsSndimYpCoqmoA%3D' (2025-09-10)
• Updated input 'hyprland/hyprland-qtutils':
    'github:hyprwm/hyprland-qtutils/b308a818b9dcaa7ab8ccab891c1b84ebde2152bc?narHash=sha256-tHe6XeNeVeKapkNM3tcjW4RuD%2BtB2iwwoogWJOtsqTI%3D' (2025-07-29)
  → 'github:hyprwm/hyprland-qtutils/119bcb9aa742658107b326c50dcd24ab59b309b7?narHash=sha256-bTYedtQFqqVBAh42scgX7%2BS3O6XKLnT6FTC6rpmyCCc%3D' (2025-09-10)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/23f0debd2003f17bd65f851cd3f930cff8a8c809?narHash=sha256-0K%2BA%2BgmOI8IklSg5It1nyRNv0kCNL51duwnhUO/B8JA%3D' (2025-07-27)
  → 'github:hyprwm/hyprlang/3d63fb4a42c819f198deabd18c0c2c1ded1de931?narHash=sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA%3D' (2025-09-02)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/e891a93b193fcaf2fc8012d890dc7f0befe86ec2?narHash=sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs%3D' (2025-08-23)
  → 'github:cachix/git-hooks.nix/b084b2c2b6bc23e83bbfe583b03664eb0b18c411?narHash=sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U%3D' (2025-09-11)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/b8d6d369618078b2dbb043480ca65fe3521f273b?narHash=sha256-%2BRLX4BmuMw4c97npsBcjjEuy%2Bs83POX9Yp8Nkj499lA%3D' (2025-09-02)
  → 'github:hyprwm/hyprland-plugins/27e1ad9042ebc01700fb56350e62a75a7da37a83?narHash=sha256-tbNzBbtkTuoO89Pd0mETjLlZ1VSMCSEeAadOGu98PAA%3D' (2025-09-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9?narHash=sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4%3D' (2025-09-05)
  → 'github:NixOS/nixpkgs/ab0f3607a6c7486ea22229b92ed2d355f1482ee0?narHash=sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/%2BG0lKfv4kk/5Izdg%3D' (2025-09-10)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/fe83bbdde2ccdc2cb9573aa846abe8363f79a97a?narHash=sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0%3D' (2025-09-04)
  → 'github:NixOS/nixpkgs/8cd5ce828d5d1d16feff37340171a98fc3bf6526?narHash=sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ%3D' (2025-09-10)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/5467c9150dd1fc9f350f084419641f0f81b5074f?narHash=sha256-E5vq21SSmmQY1w4Mj2xBr6u6Cdo7o7IOkcI4rWp4JDY%3D' (2025-09-09)
  → 'github:derethil/nvim-config/1a1e583f4ad2b0a955b67d62d02851725fc1f8ee?narHash=sha256-FyLi%2B0HFI%2BTRBq76LFDhuKbvLpWa3F4WyQuXfRhOkDY%3D' (2025-09-12)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3223c7a92724b5d804e9988c6b447a0d09017d48?narHash=sha256-t%2Bvoe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U%3D' (2025-08-12)
  → 'github:Mic92/sops-nix/0bf793823386187dff101ee2a9d4ed26de8bbf8c?narHash=sha256-S9F6bHUBh%2BCFEUalv/qxNImRapCxvSnOzWBUZgK1zDU%3D' (2025-09-10)```