### PR TITLE
chore(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755946532,
-        "narHash": "sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l+bIxdT5gc=",
+        "lastModified": 1759499898,
+        "narHash": "sha256-UNzYHLWfkSzLHDep5Ckb5tXc0fdxwPIrT+MY4kpQttM=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "81584dae2df6ac79f6b6dae0ecb7705e95129ada",
+        "rev": "655e067f96fd44b3f5685e17f566b0e4d535d798",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1759080378,
-        "narHash": "sha256-IM6e2yTFnAi/giw7+WZ72SaQl/Ppxw4C8a6ZCwerpRM=",
+        "lastModified": 1759577783,
+        "narHash": "sha256-HxaE/FVowLLEy0k6MQF5DK4spab7TDnkja+IfwE1+ls=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "a310e3d8fa42db1b393e77731a5df561955eff74",
+        "rev": "44d6f8f15cb56a3da6fd759eaa1f213676b0af89",
         "type": "github"
       },
       "original": {
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758102940,
-        "narHash": "sha256-wwqf3+A8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o=",
+        "lastModified": 1758805352,
+        "narHash": "sha256-BHdc43Lkayd+72W/NXRKHzX5AZ+28F3xaUs3a88/Uew=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd",
+        "rev": "c48e963a5558eb1c3827d59d21c5193622a1477c",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1758295658,
-        "narHash": "sha256-PsQSN226ZZ4KnweNspxKTzF8ztdPOAT6+gpGkxnygpg=",
+        "lastModified": 1759550619,
+        "narHash": "sha256-E5u2A4sEvlyL2L6vam93fXhT1z3vke+7nRHEVqm+j8w=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "7c0e1d343108cbaaf448353fadb62190246251a8",
+        "rev": "77baff367f8f79fc3227a956b8f7b173d9b3e08b",
         "type": "gitlab"
       },
       "original": {
@@ -733,11 +733,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758296614,
-        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
+        "lastModified": 1759573136,
+        "narHash": "sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
+        "rev": "5f06ceafc6c9b773a776b9195c3f47bbe1defa43",
         "type": "github"
       },
       "original": {
@@ -815,11 +815,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758192433,
-        "narHash": "sha256-CR6RnqEJSTiFgA6KQY4TTLUWbZ8RBnb+hxQqesuQNzQ=",
+        "lastModified": 1759490292,
+        "narHash": "sha256-T6iWzDOXp8Wv0KQOCTHpBcmAOdHJ6zc/l9xaztW6Ivc=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "c44e749dd611521dee940d00f7c444ee0ae4cfb7",
+        "rev": "9431db625cd9bb66ac55525479dce694101d6d7a",
         "type": "github"
       },
       "original": {
@@ -846,11 +846,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1758293956,
-        "narHash": "sha256-+UCEuPcCsWkyQh73KouiVZmcsW6ljVKHUUXDcJNI41w=",
+        "lastModified": 1759530922,
+        "narHash": "sha256-9NgZKpibALekGTPDc2O8lP8vFealQSZkXe+L+S7MMZU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "88326075743a677e76645ff163b392490419d4de",
+        "rev": "76d998743ac10e712238c1016db4d8e8d16f1049",
         "type": "github"
       },
       "original": {
@@ -875,11 +875,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758233058,
-        "narHash": "sha256-/iDzbUbpJSB046mGrtxSYhRG0Q4Ug05yHnpTyX9liZg=",
+        "lastModified": 1758895089,
+        "narHash": "sha256-HOIITlSwB5iuVEVLmWNGu8bvI83Y2IbN8SzJQmBDwvg=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "ebb4040cacf996ea802fe7a7cd5a474f9e9017d7",
+        "rev": "4d940a10aff16b240533c9b6527a14ff91e5e5ae",
         "type": "github"
       },
       "original": {
@@ -968,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757694755,
-        "narHash": "sha256-j+w5QUUr2QT/jkxgVKecGYV8J7fpzXCMgzEEr6LG9ug=",
+        "lastModified": 1759080228,
+        "narHash": "sha256-RgDoAja0T1hnF0pTc56xPfLfFOO8Utol2iITwYbUhTk=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "5ffdfc13ed03df1dae5084468d935f0a3f2c9a4c",
+        "rev": "629b15c19fa4082e4ce6be09fdb89e8c3312aed7",
         "type": "github"
       },
       "original": {
@@ -997,11 +997,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756810301,
-        "narHash": "sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA=",
+        "lastModified": 1758927902,
+        "narHash": "sha256-LZgMds7M94+vuMql2bERQ6LiFFdhgsEFezE4Vn+Ys3A=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "3d63fb4a42c819f198deabd18c0c2c1ded1de931",
+        "rev": "4dafa28d4f79877d67a7d1a654cddccf8ebf15da",
         "type": "github"
       },
       "original": {
@@ -1022,11 +1022,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756117388,
-        "narHash": "sha256-oRDel6pNl/T2tI+nc/USU9ZP9w08dxtl7hiZxa0C/Wc=",
+        "lastModified": 1759490926,
+        "narHash": "sha256-7IbZGJ5qAAfZsGhBHIsP8MBsfuFYS0hsxYHVkkeDG5Q=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "b2ae3204845f5f2f79b4703b441252d8ad2ecfd0",
+        "rev": "94cce794344538c4d865e38682684ec2bbdb2ef3",
         "type": "github"
       },
       "original": {
@@ -1297,11 +1297,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1758216857,
-        "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2ed99647a4b195f0bcc440f76edfa10aeb3b743",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
         "type": "github"
       },
       "original": {
@@ -1329,11 +1329,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
@@ -1433,11 +1433,11 @@
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1759092938,
-        "narHash": "sha256-+iazbSDv5klE3zwfuoYI2iSFtpZuYJ1snwExKf3nlRo=",
+        "lastModified": 1759125661,
+        "narHash": "sha256-qix2p5loGtl/HhWfNzPEzWhoZu4WufPnkpa0oAke9x4=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "69f512bd76b034442e85bb3d4401762ad77dd776",
+        "rev": "da47be6a6288045d649b4a0a9f43b4d790b4b2ef",
         "type": "github"
       },
       "original": {
@@ -1477,11 +1477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759208386,
-        "narHash": "sha256-IQCtGpy+Z1GupmTeJKSb/bXf097jL5fnsGnP8PArkPo=",
+        "lastModified": 1756981260,
+        "narHash": "sha256-GhuD9QVimjynHI0OOyZsqJsnlXr2orowh9H+HYz4YMs=",
         "ref": "refs/heads/master",
-        "rev": "482744cfa95cdb76a6175d08f29f35005b8e0887",
-        "revCount": 684,
+        "rev": "6eb12551baf924f8fdecdd04113863a754259c34",
+        "revCount": 672,
         "type": "git",
         "url": "https://git.outfoxxed.me/quickshell/quickshell"
       },
@@ -1497,11 +1497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759208386,
-        "narHash": "sha256-IQCtGpy+Z1GupmTeJKSb/bXf097jL5fnsGnP8PArkPo=",
+        "lastModified": 1759303785,
+        "narHash": "sha256-EUXrK7pUIzOQWR1dquZh26A6W8lsY2oiHEEZzQnsarM=",
         "ref": "master",
-        "rev": "482744cfa95cdb76a6175d08f29f35005b8e0887",
-        "revCount": 684,
+        "rev": "9662234759eb57f2a1057f2a1c667da1bf128c1c",
+        "revCount": 686,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1657,11 +1657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758007585,
-        "narHash": "sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c=",
+        "lastModified": 1759188042,
+        "narHash": "sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f77d4cfa075c3de66fc9976b80e0c4fc69e2c139",
+        "rev": "9fcfabe085281dd793589bdc770a2e577a3caa5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/a310e3d8fa42db1b393e77731a5df561955eff74?narHash=sha256-IM6e2yTFnAi/giw7%2BWZ72SaQl/Ppxw4C8a6ZCwerpRM%3D' (2025-09-28)
  → 'github:AvengeMedia/DankMaterialShell/44d6f8f15cb56a3da6fd759eaa1f213676b0af89?narHash=sha256-HxaE/FVowLLEy0k6MQF5DK4spab7TDnkja%2BIfwE1%2Bls%3D' (2025-10-04)
• Updated input 'dank-material-shell/quickshell':
    'git+https://git.outfoxxed.me/quickshell/quickshell?ref=refs/heads/master&rev=482744cfa95cdb76a6175d08f29f35005b8e0887' (2025-09-30)
  → 'git+https://git.outfoxxed.me/quickshell/quickshell?ref=refs/heads/master&rev=6eb12551baf924f8fdecdd04113863a754259c34' (2025-09-04)
• Updated input 'darwin':
    'github:LnL7/nix-darwin/ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd?narHash=sha256-wwqf3%2BA8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o%3D' (2025-09-17)
  → 'github:LnL7/nix-darwin/c48e963a5558eb1c3827d59d21c5193622a1477c?narHash=sha256-BHdc43Lkayd%2B72W/NXRKHzX5AZ%2B28F3xaUs3a88/Uew%3D' (2025-09-25)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/7c0e1d343108cbaaf448353fadb62190246251a8?dir=pkgs/firefox-addons&narHash=sha256-PsQSN226ZZ4KnweNspxKTzF8ztdPOAT6%2BgpGkxnygpg%3D' (2025-09-19)
  → 'gitlab:rycee/nur-expressions/77baff367f8f79fc3227a956b8f7b173d9b3e08b?dir=pkgs/firefox-addons&narHash=sha256-E5u2A4sEvlyL2L6vam93fXhT1z3vke%2B7nRHEVqm%2Bj8w%3D' (2025-10-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/55b1f5b7b191572257545413b98e37abab2fdb00?narHash=sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY%2Bq0kQ%3D' (2025-09-19)
  → 'github:nix-community/home-manager/5f06ceafc6c9b773a776b9195c3f47bbe1defa43?narHash=sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE%3D' (2025-10-04)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/88326075743a677e76645ff163b392490419d4de?narHash=sha256-%2BUCEuPcCsWkyQh73KouiVZmcsW6ljVKHUUXDcJNI41w%3D' (2025-09-19)
  → 'github:hyprwm/Hyprland/76d998743ac10e712238c1016db4d8e8d16f1049?narHash=sha256-9NgZKpibALekGTPDc2O8lP8vFealQSZkXe%2BL%2BS7MMZU%3D' (2025-10-03)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/81584dae2df6ac79f6b6dae0ecb7705e95129ada?narHash=sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l%2BbIxdT5gc%3D' (2025-08-23)
  → 'github:hyprwm/aquamarine/655e067f96fd44b3f5685e17f566b0e4d535d798?narHash=sha256-UNzYHLWfkSzLHDep5Ckb5tXc0fdxwPIrT%2BMY4kpQttM%3D' (2025-10-03)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/c44e749dd611521dee940d00f7c444ee0ae4cfb7?narHash=sha256-CR6RnqEJSTiFgA6KQY4TTLUWbZ8RBnb%2BhxQqesuQNzQ%3D' (2025-09-18)
  → 'github:hyprwm/hyprgraphics/9431db625cd9bb66ac55525479dce694101d6d7a?narHash=sha256-T6iWzDOXp8Wv0KQOCTHpBcmAOdHJ6zc/l9xaztW6Ivc%3D' (2025-10-03)
• Updated input 'hyprland/hyprland-qtutils':
    'github:hyprwm/hyprland-qtutils/5ffdfc13ed03df1dae5084468d935f0a3f2c9a4c?narHash=sha256-j%2Bw5QUUr2QT/jkxgVKecGYV8J7fpzXCMgzEEr6LG9ug%3D' (2025-09-12)
  → 'github:hyprwm/hyprland-qtutils/629b15c19fa4082e4ce6be09fdb89e8c3312aed7?narHash=sha256-RgDoAja0T1hnF0pTc56xPfLfFOO8Utol2iITwYbUhTk%3D' (2025-09-28)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/3d63fb4a42c819f198deabd18c0c2c1ded1de931?narHash=sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA%3D' (2025-09-02)
  → 'github:hyprwm/hyprlang/4dafa28d4f79877d67a7d1a654cddccf8ebf15da?narHash=sha256-LZgMds7M94%2BvuMql2bERQ6LiFFdhgsEFezE4Vn%2BYs3A%3D' (2025-09-26)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/b2ae3204845f5f2f79b4703b441252d8ad2ecfd0?narHash=sha256-oRDel6pNl/T2tI%2Bnc/USU9ZP9w08dxtl7hiZxa0C/Wc%3D' (2025-08-25)
  → 'github:hyprwm/hyprutils/94cce794344538c4d865e38682684ec2bbdb2ef3?narHash=sha256-7IbZGJ5qAAfZsGhBHIsP8MBsfuFYS0hsxYHVkkeDG5Q%3D' (2025-10-03)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/ebb4040cacf996ea802fe7a7cd5a474f9e9017d7?narHash=sha256-/iDzbUbpJSB046mGrtxSYhRG0Q4Ug05yHnpTyX9liZg%3D' (2025-09-18)
  → 'github:hyprwm/hyprland-plugins/4d940a10aff16b240533c9b6527a14ff91e5e5ae?narHash=sha256-HOIITlSwB5iuVEVLmWNGu8bvI83Y2IbN8SzJQmBDwvg%3D' (2025-09-26)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/8eaee110344796db060382e15d3af0a9fc396e0e?narHash=sha256-iCGWf/LTy%2BaY0zFu8q12lK8KuZp7yvdhStehhyX1v8w%3D' (2025-09-19)
  → 'github:NixOS/nixpkgs/7df7ff7d8e00218376575f0acdcc5d66741351ee?narHash=sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs%3D' (2025-10-02)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/d2ed99647a4b195f0bcc440f76edfa10aeb3b743?narHash=sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY%3D' (2025-09-18)
  → 'github:NixOS/nixpkgs/879bd460b3d3e8571354ce172128fbcbac1ed633?narHash=sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI%3D' (2025-10-02)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/69f512bd76b034442e85bb3d4401762ad77dd776?narHash=sha256-%2BiazbSDv5klE3zwfuoYI2iSFtpZuYJ1snwExKf3nlRo%3D' (2025-09-28)
  → 'github:derethil/nvim-config/da47be6a6288045d649b4a0a9f43b4d790b4b2ef?narHash=sha256-qix2p5loGtl/HhWfNzPEzWhoZu4WufPnkpa0oAke9x4%3D' (2025-09-29)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=482744cfa95cdb76a6175d08f29f35005b8e0887' (2025-09-30)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=9662234759eb57f2a1057f2a1c667da1bf128c1c' (2025-10-01)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f77d4cfa075c3de66fc9976b80e0c4fc69e2c139?narHash=sha256-HYnwlbY6RE5xVd5rh0bYw77pnD8lOgbT4mlrfjgNZ0c%3D' (2025-09-16)
  → 'github:Mic92/sops-nix/9fcfabe085281dd793589bdc770a2e577a3caa5d?narHash=sha256-f9QC2KKiNReZDG2yyKAtDZh0rSK2Xp1wkPzKbHeQVRU%3D' (2025-09-29)```