### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759499898,
-        "narHash": "sha256-UNzYHLWfkSzLHDep5Ckb5tXc0fdxwPIrT+MY4kpQttM=",
+        "lastModified": 1760101617,
+        "narHash": "sha256-8jf/3ZCi+B7zYpIyV04+3wm72BD7Z801IlOzsOACR7I=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "655e067f96fd44b3f5685e17f566b0e4d535d798",
+        "rev": "1826a9923881320306231b1c2090379ebf9fa4f8",
         "type": "github"
       },
       "original": {
@@ -181,15 +181,14 @@
         "dms-cli": "dms-cli",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "quickshell": "quickshell"
+        ]
       },
       "locked": {
-        "lastModified": 1760731392,
-        "narHash": "sha256-tO4k932ag1WCQ6BfsCKTBaIokBjzB5cu7q0K1K9+KlU=",
+        "lastModified": 1761372093,
+        "narHash": "sha256-IkIMJ4ZqEKeWYSXA3qbJCXSyn0Gg7hYn/K8haodirTA=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "205c43181b135f5ad6cee445179222cf6c2de777",
+        "rev": "9774991b5647ba55a9e46105c76600e8914eeafd",
         "type": "github"
       },
       "original": {
@@ -205,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760338583,
-        "narHash": "sha256-IGwy02SH5K2hzIFrKMRsCmyvwOwWxrcquiv4DbKL1S4=",
+        "lastModified": 1761339987,
+        "narHash": "sha256-IUaawVwItZKi64IA6kF6wQCLCzpXbk2R46dHn8sHkig=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9a9ab01072f78823ca627ae5e895e40d493c3ecf",
+        "rev": "7cd9aac79ee2924a85c211d21fafd394b06a38de",
         "type": "github"
       },
       "original": {
@@ -241,17 +240,18 @@
     },
     "dms-cli": {
       "inputs": {
+        "gomod2nix": "gomod2nix",
         "nixpkgs": [
           "dank-material-shell",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1760241259,
-        "narHash": "sha256-DlLGn+4M6tIafoDsHr2WhHG2hrHrC24S2IL3+KAvjEU=",
+        "lastModified": 1761135910,
+        "narHash": "sha256-51m0k2BN6EjUKZI/tRs563HqGPhsM639kwuXcqxuniM=",
         "owner": "AvengeMedia",
         "repo": "danklinux",
-        "rev": "dae4c3ff4ce0feb930361c399747edb29d081775",
+        "rev": "d42b58f35c129e893819742746f11ef7e82be56f",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1760587417,
-        "narHash": "sha256-zoEJAw7naU8QZiH4x4JN/lgUgdA4H2Stk1N2KgWA1TI=",
+        "lastModified": 1761392505,
+        "narHash": "sha256-Z3qLXGiB3Xk3SWW6l3bKeENhJxrUtsvCRRS0JgilVaU=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "b37dfe9a29574b11182dac6b9b2bdb6b55948520",
+        "rev": "30690e168e5fcb599cf7c4a4e09368dd3c573621",
         "type": "gitlab"
       },
       "original": {
@@ -482,10 +482,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": [
-          "mac-app-util",
-          "systems"
-        ]
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -496,13 +493,14 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "flake-utils-plus": {
       "inputs": {
-        "flake-utils": "flake-utils_4"
+        "flake-utils": "flake-utils_5"
       },
       "locked": {
         "lastModified": 1715533576,
@@ -521,7 +519,10 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": [
+          "mac-app-util",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -532,14 +533,13 @@
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-utils",
+        "type": "indirect"
       }
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -558,6 +558,24 @@
     "flake-utils_4": {
       "inputs": {
         "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -681,6 +699,30 @@
         "type": "github"
       }
     },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "dank-material-shell",
+          "dms-cli",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756047880,
+        "narHash": "sha256-JeuGh9kA1SPL70fnvpLxkIkCWpTjtoPaus3jzvdna0k=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "47d628dc3b506bd28632e47280c6b89d3496909d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.7.0",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
     "hercules-ci-effects": {
       "inputs": {
         "flake-parts": [
@@ -715,11 +757,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760662441,
-        "narHash": "sha256-mlDqR1Ntgs9uYYEAUR1IhamKBO0lxoNS4zGLzEZaY0A=",
+        "lastModified": 1761344779,
+        "narHash": "sha256-6LNSptFYhiAd0M/maJoixJw7V0Kp5BSoMRtIahcfu3M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "722792af097dff5790f1a66d271a47759f477755",
+        "rev": "c644cb018f9fdec55f5ac2afb4713a8c7beb757c",
         "type": "github"
       },
       "original": {
@@ -797,11 +839,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759490292,
-        "narHash": "sha256-T6iWzDOXp8Wv0KQOCTHpBcmAOdHJ6zc/l9xaztW6Ivc=",
+        "lastModified": 1760445448,
+        "narHash": "sha256-fXGjL6dw31FPFRrmIemzGiNSlfvEJTJNsmadZi+qNhI=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "9431db625cd9bb66ac55525479dce694101d6d7a",
+        "rev": "50fb9f069219f338a11cf0bcccb9e58357d67757",
         "type": "github"
       },
       "original": {
@@ -824,15 +866,15 @@
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems",
+        "systems": "systems_2",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1760621586,
-        "narHash": "sha256-sIbe3te3RrL9PY4ASKGwv1KuJs0pyn4Zvo3xIF3jFms=",
+        "lastModified": 1761389866,
+        "narHash": "sha256-RupwqaJ3JF5dF9iuJX+y0EZslmIuRs7+n+wnngtBqak=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "8164b90bc2839d4d2a10c0d2b26c4a413ecf90b2",
+        "rev": "b10b9660004b3dfaf9e11a305d78f24955b089a4",
         "type": "github"
       },
       "original": {
@@ -857,11 +899,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760659005,
-        "narHash": "sha256-wyS6tXYJuzbwckOeaCoRtT4qIG2UZ0YvSZx7EBNjTV0=",
+        "lastModified": 1761249285,
+        "narHash": "sha256-70dEwL5p3CB/00ODs2RHWUKTyafB+PF4Ld7IEMuO+no=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "a5a6f93d72d5fb37e78b98c756cfd8b340e71a19",
+        "rev": "81f6d1426537981fcbb921f8b5e470b1280ef8f3",
         "type": "github"
       },
       "original": {
@@ -882,11 +924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749046714,
-        "narHash": "sha256-kymV5FMnddYGI+UjwIw8ceDjdeg7ToDVjbHCvUlhn14=",
+        "lastModified": 1759610243,
+        "narHash": "sha256-+KEVnKBe8wz+a6dTLq8YDcF3UrhQElwsYJaVaHXJtoI=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "613878cb6f459c5e323aaafe1e6f388ac8a36330",
+        "rev": "bd153e76f751f150a09328dbdeb5e4fab9d23622",
         "type": "github"
       },
       "original": {
@@ -1135,9 +1177,9 @@
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_3",
+        "systems": "systems_4",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -1243,11 +1285,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1760575912,
-        "narHash": "sha256-8VNgyBHMJ2paTzWX5EAemGBNB0pCiA6NKJFPZHuzjhY=",
+        "lastModified": 1761348525,
+        "narHash": "sha256-V738NRqRVHCug0rPbYmXFAZsQnqmQAurDzu54WY/YIk=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "55d6c441e21c9cd8396d4db03c696c1259d0f62e",
+        "rev": "34e1de2311cda824f7685f2e2cd9453263ef75d5",
         "type": "github"
       },
       "original": {
@@ -1276,11 +1318,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1760524031,
-        "narHash": "sha256-hcyRViwdsrNUjHTcY0VGygcAawcyU4zYEq7ZZObFwkw=",
+        "lastModified": 1761337523,
+        "narHash": "sha256-j6hQ1B7TJt9irtvt2Kxbrb8pq16C8yv4w+M/Dbghabw=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "2776005c5fc4fbb85636672213b8b84a319dfb01",
+        "rev": "4310c20c320d040f3df7a93de4064e452a1876ae",
         "type": "github"
       },
       "original": {
@@ -1311,11 +1353,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1760942919,
-        "narHash": "sha256-/CoMM0vhhihs5/9QLXgL/kkyALBa9XyVTSkN9Htxtjc=",
+        "lastModified": 1761356901,
+        "narHash": "sha256-YDySchURSJrS1P8zuzmFqypUS7shY6//0e0JiMZeLSI=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "6fa7d37d878cceeaa3c88e2606dbadf15c8022ad",
+        "rev": "a8635e459ff96acbd156a8de613b99d9d6b3676a",
         "type": "github"
       },
       "original": {
@@ -1326,7 +1368,7 @@
     },
     "nixgl": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1408,11 +1450,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1760423683,
-        "narHash": "sha256-Tb+NYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8=",
+        "lastModified": 1761173472,
+        "narHash": "sha256-m9W0dYXflzeGgKNravKJvTMR4Qqa2MVD11AwlGMufeE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2",
+        "rev": "c8aa8cc00a5cb57fada0851a038d35c08a36a2bb",
         "type": "github"
       },
       "original": {
@@ -1424,11 +1466,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1760423683,
-        "narHash": "sha256-Tb+NYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8=",
+        "lastModified": 1761173472,
+        "narHash": "sha256-m9W0dYXflzeGgKNravKJvTMR4Qqa2MVD11AwlGMufeE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2",
+        "rev": "c8aa8cc00a5cb57fada0851a038d35c08a36a2bb",
         "type": "github"
       },
       "original": {
@@ -1472,11 +1514,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1760524057,
-        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {
@@ -1543,7 +1585,7 @@
           "nvim-config",
           "nixpkgs"
         ],
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1759942631,
@@ -1616,11 +1658,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1760663237,
+        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
         "type": "github"
       },
       "original": {
@@ -1632,36 +1674,15 @@
     "quickshell": {
       "inputs": {
         "nixpkgs": [
-          "dank-material-shell",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1760228179,
-        "narHash": "sha256-4Z6k7lv3Zcgk3K+4h60LpqB9wCkR+utkYERU735U068=",
-        "ref": "refs/heads/master",
-        "rev": "c9d3ffb6043c5bf3f3009202bad7e0e5132c4a25",
-        "revCount": 693,
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      }
-    },
-    "quickshell_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1760315601,
-        "narHash": "sha256-cvguRikKX0yXZ7jaK4Gt3qB1I33T5TzYZQf0Ampx8ko=",
+        "lastModified": 1760822546,
+        "narHash": "sha256-cy3wJQQzQbZ/EYUfTDuMiP/haPOjkqGgWOPPl7K9oiM=",
         "ref": "master",
-        "rev": "00858812f25b748d08b075a0d284093685fa3ffd",
-        "revCount": 696,
+        "rev": "3e2ce40b18af943f9ba370ed73565e9f487663ef",
+        "revCount": 697,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1693,7 +1714,7 @@
         "nixpkgs-for-stremio": "nixpkgs-for-stremio",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nvim-config": "nvim-config",
-        "quickshell": "quickshell_2",
+        "quickshell": "quickshell",
         "rust-system-scripts": "rust-system-scripts",
         "secrets": "secrets",
         "snowfall-lib": "snowfall-lib",
@@ -1738,7 +1759,7 @@
     },
     "rust-system-scripts": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1820,11 +1841,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760393368,
-        "narHash": "sha256-8mN3kqyqa2PKY0wwZ2UmMEYMcxvNTwLaOrrDsw6Qi4E=",
+        "lastModified": 1760998189,
+        "narHash": "sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ab8d56e85b8be14cff9d93735951e30c3e86a437",
+        "rev": "5a7d18b5c55642df5c432aadb757140edfeb70b3",
         "type": "github"
       },
       "original": {
@@ -1834,6 +1855,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
@@ -1848,7 +1884,7 @@
         "type": "github"
       }
     },
-    "systems_2": {
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1863,7 +1899,7 @@
         "type": "github"
       }
     },
-    "systems_3": {
+    "systems_4": {
       "locked": {
         "lastModified": 1689347925,
         "narHash": "sha256-ozenz5bFe1UUqOn7f60HRmgc01BgTGIKZ4Xl+HbocGQ=",
@@ -1875,21 +1911,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-darwin",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     },
@@ -1924,6 +1945,21 @@
       }
     },
     "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2012,7 +2048,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -2056,11 +2092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755354946,
-        "narHash": "sha256-zdov5f/GcoLQc9qYIS1dUTqtJMeDqmBmo59PAxze6e4=",
+        "lastModified": 1760713634,
+        "narHash": "sha256-5HXelmz2x/uO26lvW7MudnadbAfoBnve4tRBiDVLtOM=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "a10726d6a8d0ef1a0c645378f983b6278c42eaa0",
+        "rev": "753bbbdf6a052994da94062e5b753288cef28dfb",
         "type": "github"
       },
       "original": {
@@ -2089,11 +2125,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1759707084,
-        "narHash": "sha256-0pkftKs6/LReNvxw7DVTN2AJEheZVgyeK0Aarbagi70=",
+        "lastModified": 1761345612,
+        "narHash": "sha256-ph61jGpaonY04jdfQxkBYRgw7ptlNHo7K0W+5kCV/+0=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "a9188e70bd748118b4d56a529871b9de5adb9988",
+        "rev": "04816e2a3634087db3de39043fcc9db2afcb0c44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/205c43181b135f5ad6cee445179222cf6c2de777?narHash=sha256-tO4k932ag1WCQ6BfsCKTBaIokBjzB5cu7q0K1K9%2BKlU%3D' (2025-10-17)
  → 'github:AvengeMedia/DankMaterialShell/9774991b5647ba55a9e46105c76600e8914eeafd?narHash=sha256-IkIMJ4ZqEKeWYSXA3qbJCXSyn0Gg7hYn/K8haodirTA%3D' (2025-10-25)
• Updated input 'dank-material-shell/dms-cli':
    'github:AvengeMedia/danklinux/dae4c3ff4ce0feb930361c399747edb29d081775?narHash=sha256-DlLGn%2B4M6tIafoDsHr2WhHG2hrHrC24S2IL3%2BKAvjEU%3D' (2025-10-12)
  → 'github:AvengeMedia/danklinux/d42b58f35c129e893819742746f11ef7e82be56f?narHash=sha256-51m0k2BN6EjUKZI/tRs563HqGPhsM639kwuXcqxuniM%3D' (2025-10-22)
• Added input 'dank-material-shell/dms-cli/gomod2nix':
    'github:nix-community/gomod2nix/47d628dc3b506bd28632e47280c6b89d3496909d?narHash=sha256-JeuGh9kA1SPL70fnvpLxkIkCWpTjtoPaus3jzvdna0k%3D' (2025-08-24)
• Added input 'dank-material-shell/dms-cli/gomod2nix/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'dank-material-shell/dms-cli/gomod2nix/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Added input 'dank-material-shell/dms-cli/gomod2nix/nixpkgs':
    follows 'dank-material-shell/dms-cli/nixpkgs'
• Removed input 'dank-material-shell/quickshell'
• Removed input 'dank-material-shell/quickshell/nixpkgs'
• Updated input 'darwin':
    'github:LnL7/nix-darwin/9a9ab01072f78823ca627ae5e895e40d493c3ecf?narHash=sha256-IGwy02SH5K2hzIFrKMRsCmyvwOwWxrcquiv4DbKL1S4%3D' (2025-10-13)
  → 'github:LnL7/nix-darwin/7cd9aac79ee2924a85c211d21fafd394b06a38de?narHash=sha256-IUaawVwItZKi64IA6kF6wQCLCzpXbk2R46dHn8sHkig%3D' (2025-10-24)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/b37dfe9a29574b11182dac6b9b2bdb6b55948520?dir=pkgs/firefox-addons&narHash=sha256-zoEJAw7naU8QZiH4x4JN/lgUgdA4H2Stk1N2KgWA1TI%3D' (2025-10-16)
  → 'gitlab:rycee/nur-expressions/30690e168e5fcb599cf7c4a4e09368dd3c573621?dir=pkgs/firefox-addons&narHash=sha256-Z3qLXGiB3Xk3SWW6l3bKeENhJxrUtsvCRRS0JgilVaU%3D' (2025-10-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/722792af097dff5790f1a66d271a47759f477755?narHash=sha256-mlDqR1Ntgs9uYYEAUR1IhamKBO0lxoNS4zGLzEZaY0A%3D' (2025-10-17)
  → 'github:nix-community/home-manager/c644cb018f9fdec55f5ac2afb4713a8c7beb757c?narHash=sha256-6LNSptFYhiAd0M/maJoixJw7V0Kp5BSoMRtIahcfu3M%3D' (2025-10-24)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/8164b90bc2839d4d2a10c0d2b26c4a413ecf90b2?narHash=sha256-sIbe3te3RrL9PY4ASKGwv1KuJs0pyn4Zvo3xIF3jFms%3D' (2025-10-16)
  → 'github:hyprwm/Hyprland/b10b9660004b3dfaf9e11a305d78f24955b089a4?narHash=sha256-RupwqaJ3JF5dF9iuJX%2By0EZslmIuRs7%2Bn%2BwnngtBqak%3D' (2025-10-25)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/655e067f96fd44b3f5685e17f566b0e4d535d798?narHash=sha256-UNzYHLWfkSzLHDep5Ckb5tXc0fdxwPIrT%2BMY4kpQttM%3D' (2025-10-03)
  → 'github:hyprwm/aquamarine/1826a9923881320306231b1c2090379ebf9fa4f8?narHash=sha256-8jf/3ZCi%2BB7zYpIyV04%2B3wm72BD7Z801IlOzsOACR7I%3D' (2025-10-10)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/9431db625cd9bb66ac55525479dce694101d6d7a?narHash=sha256-T6iWzDOXp8Wv0KQOCTHpBcmAOdHJ6zc/l9xaztW6Ivc%3D' (2025-10-03)
  → 'github:hyprwm/hyprgraphics/50fb9f069219f338a11cf0bcccb9e58357d67757?narHash=sha256-fXGjL6dw31FPFRrmIemzGiNSlfvEJTJNsmadZi%2BqNhI%3D' (2025-10-14)
• Updated input 'hyprland/hyprland-protocols':
    'github:hyprwm/hyprland-protocols/613878cb6f459c5e323aaafe1e6f388ac8a36330?narHash=sha256-kymV5FMnddYGI%2BUjwIw8ceDjdeg7ToDVjbHCvUlhn14%3D' (2025-06-04)
  → 'github:hyprwm/hyprland-protocols/bd153e76f751f150a09328dbdeb5e4fab9d23622?narHash=sha256-%2BKEVnKBe8wz%2Ba6dTLq8YDcF3UrhQElwsYJaVaHXJtoI%3D' (2025-10-04)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b?narHash=sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo%3D' (2025-09-17)
  → 'github:cachix/git-hooks.nix/ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37?narHash=sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc%3D' (2025-10-17)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/a10726d6a8d0ef1a0c645378f983b6278c42eaa0?narHash=sha256-zdov5f/GcoLQc9qYIS1dUTqtJMeDqmBmo59PAxze6e4%3D' (2025-08-16)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/753bbbdf6a052994da94062e5b753288cef28dfb?narHash=sha256-5HXelmz2x/uO26lvW7MudnadbAfoBnve4tRBiDVLtOM%3D' (2025-10-17)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/a5a6f93d72d5fb37e78b98c756cfd8b340e71a19?narHash=sha256-wyS6tXYJuzbwckOeaCoRtT4qIG2UZ0YvSZx7EBNjTV0%3D' (2025-10-16)
  → 'github:hyprwm/hyprland-plugins/81f6d1426537981fcbb921f8b5e470b1280ef8f3?narHash=sha256-70dEwL5p3CB/00ODs2RHWUKTyafB%2BPF4Ld7IEMuO%2Bno%3D' (2025-10-23)
• Updated input 'niri':
    'github:sodiboo/niri-flake/55d6c441e21c9cd8396d4db03c696c1259d0f62e?narHash=sha256-8VNgyBHMJ2paTzWX5EAemGBNB0pCiA6NKJFPZHuzjhY%3D' (2025-10-16)
  → 'github:sodiboo/niri-flake/34e1de2311cda824f7685f2e2cd9453263ef75d5?narHash=sha256-V738NRqRVHCug0rPbYmXFAZsQnqmQAurDzu54WY/YIk%3D' (2025-10-24)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/2776005c5fc4fbb85636672213b8b84a319dfb01?narHash=sha256-hcyRViwdsrNUjHTcY0VGygcAawcyU4zYEq7ZZObFwkw%3D' (2025-10-15)
  → 'github:YaLTeR/niri/4310c20c320d040f3df7a93de4064e452a1876ae?narHash=sha256-j6hQ1B7TJt9irtvt2Kxbrb8pq16C8yv4w%2BM/Dbghabw%3D' (2025-10-24)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2?narHash=sha256-Tb%2BNYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8%3D' (2025-10-14)
  → 'github:NixOS/nixpkgs/c8aa8cc00a5cb57fada0851a038d35c08a36a2bb?narHash=sha256-m9W0dYXflzeGgKNravKJvTMR4Qqa2MVD11AwlGMufeE%3D' (2025-10-22)
• Updated input 'niri/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/a9188e70bd748118b4d56a529871b9de5adb9988?narHash=sha256-0pkftKs6/LReNvxw7DVTN2AJEheZVgyeK0Aarbagi70%3D' (2025-10-05)
  → 'github:Supreeeme/xwayland-satellite/04816e2a3634087db3de39043fcc9db2afcb0c44?narHash=sha256-ph61jGpaonY04jdfQxkBYRgw7ptlNHo7K0W%2B5kCV/%2B0%3D' (2025-10-24)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/6fa7d37d878cceeaa3c88e2606dbadf15c8022ad?narHash=sha256-/CoMM0vhhihs5/9QLXgL/kkyALBa9XyVTSkN9Htxtjc%3D' (2025-10-20)
  → 'github:fufexan/nix-gaming/a8635e459ff96acbd156a8de613b99d9d6b3676a?narHash=sha256-YDySchURSJrS1P8zuzmFqypUS7shY6//0e0JiMZeLSI%3D' (2025-10-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/544961dfcce86422ba200ed9a0b00dd4b1486ec5?narHash=sha256-EVAqOteLBFmd7pKkb0%2BFIUyzTF61VKi7YmvP1tw4nEw%3D' (2025-10-15)
  → 'github:NixOS/nixpkgs/01f116e4df6a15f4ccdffb1bcd41096869fb385c?narHash=sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d%2BdAiC3H%2BCDle4%3D' (2025-10-22)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/a493e93b4a259cd9fea8073f89a7ed9b1c5a1da2?narHash=sha256-Tb%2BNYuJhWZieDZUxN6PgglB16yuqBYQeMJyYBGCXlt8%3D' (2025-10-14)
  → 'github:NixOS/nixpkgs/c8aa8cc00a5cb57fada0851a038d35c08a36a2bb?narHash=sha256-m9W0dYXflzeGgKNravKJvTMR4Qqa2MVD11AwlGMufeE%3D' (2025-10-22)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=00858812f25b748d08b075a0d284093685fa3ffd' (2025-10-13)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=3e2ce40b18af943f9ba370ed73565e9f487663ef' (2025-10-18)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ab8d56e85b8be14cff9d93735951e30c3e86a437?narHash=sha256-8mN3kqyqa2PKY0wwZ2UmMEYMcxvNTwLaOrrDsw6Qi4E%3D' (2025-10-13)
  → 'github:Mic92/sops-nix/5a7d18b5c55642df5c432aadb757140edfeb70b3?narHash=sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY%3D' (2025-10-20)```