### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760101617,
-        "narHash": "sha256-8jf/3ZCi+B7zYpIyV04+3wm72BD7Z801IlOzsOACR7I=",
+        "lastModified": 1762356719,
+        "narHash": "sha256-qwd/xdoOya1m8FENle+4hWnydCtlXUWLAW/Auk6WL7s=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "1826a9923881320306231b1c2090379ebf9fa4f8",
+        "rev": "6d0b3567584691bf9d8fedb5d0093309e2f979c7",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762019587,
-        "narHash": "sha256-FFfvV6DHqTvHPOc9r6Bt57rt57fek4sArQ4MgvYQo7M=",
+        "lastModified": 1762984947,
+        "narHash": "sha256-Q1sscRok5XFc1zgET2QonPNAq8ac5hurDq5zKZPJ2Y8=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "ca226e98c2d30c753c9fb000e19aded51bb78781",
+        "rev": "6013c994a66ff6e8b8f05c9465c60afda906e8cb",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759509947,
-        "narHash": "sha256-4XifSIHfpJKcCf5bZZRhj8C4aCpjNBaE3kXr02s4rHU=",
+        "lastModified": 1762912391,
+        "narHash": "sha256-4hpBE7bGd24SfD28rzMdUGXsLsNEYxCCrTipFdoqoNM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "000eadb231812ad6ea6aebd7526974aaf4e79355",
+        "rev": "d76299b2cd01837c4c271a7b5186e3d5d8ebd126",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760238269,
-        "narHash": "sha256-7CeGZM/Z/5Qt3AYByCRohGYGR1MRuXYzTTbkV/JxyAs=",
+        "lastModified": 1762435535,
+        "narHash": "sha256-QhzRn7pYN35IFpKjjxJAj3GPJECuC+VLhoGem3ezycc=",
         "owner": "AvengeMedia",
         "repo": "dgop",
-        "rev": "95acdfce2d323e28fa8f5a4f345160962034f2b5",
+        "rev": "6cf638dde818f9f8a2e26d0243179c43cb3458d7",
         "type": "github"
       },
       "original": {
@@ -257,18 +257,17 @@
     },
     "dms-cli": {
       "inputs": {
-        "gomod2nix": "gomod2nix",
         "nixpkgs": [
           "dank-material-shell",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1761135910,
-        "narHash": "sha256-51m0k2BN6EjUKZI/tRs563HqGPhsM639kwuXcqxuniM=",
+        "lastModified": 1762491516,
+        "narHash": "sha256-oGLH5Gje/p2Hc1kO3m8P5eAZ7JldBI30EmwzEET4cNU=",
         "owner": "AvengeMedia",
         "repo": "danklinux",
-        "rev": "d42b58f35c129e893819742746f11ef7e82be56f",
+        "rev": "050cf28a2963a7698ed4759736fe5fe77eee7cc2",
         "type": "github"
       },
       "original": {
@@ -280,11 +279,11 @@
     "dms-emoji-launcher": {
       "flake": false,
       "locked": {
-        "lastModified": 1761604394,
-        "narHash": "sha256-Jpz/s6ol257xn0ERNsitEJB4lPhy+lJ0mf3InInP6i8=",
+        "lastModified": 1762727274,
+        "narHash": "sha256-aub5pXRMlMs7dxiv5P+/Rz/dA4weojr+SGZAItmbOvo=",
         "owner": "devnullvoid",
         "repo": "dms-emoji-launcher",
-        "rev": "79bdec809481a2d65d18b02004a5d0195167d22c",
+        "rev": "2951ec7f823c983c11b6b231403581a386a7c9f6",
         "type": "github"
       },
       "original": {
@@ -296,11 +295,11 @@
     "dms-official-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1761499744,
-        "narHash": "sha256-piEPE5GOMKyM+y4qpfMyRlIk4GQjVxqzF5BtxOJ9UZ8=",
+        "lastModified": 1762786607,
+        "narHash": "sha256-qGseA9QsSXEffTKOvLjJDgW0V5Ej39Mc+fcMP2dcNCM=",
         "owner": "AvengeMedia",
         "repo": "dms-plugins",
-        "rev": "43ec46372c728ed416b37f66886c2a0e5aff026c",
+        "rev": "2b2353cace2bb63c3559f32576c028d52498c86c",
         "type": "github"
       },
       "original": {
@@ -333,11 +332,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1761969823,
-        "narHash": "sha256-YqUB0AYD4KbeqvSZqPhXhHBj3mLKTyuYrofyRgG3+Xc=",
+        "lastModified": 1762920261,
+        "narHash": "sha256-VuUg2EP2Y0QrDTsDP6/3kN3Hurn6HfyMW3rGzdruhW8=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "aecae658b04384b2f87249c6b93fdbfd97ef249d",
+        "rev": "8cd76837f50debe28b51820adb00b522df8ade91",
         "type": "gitlab"
       },
       "original": {
@@ -438,11 +437,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760948891,
-        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "lastModified": 1762440070,
+        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
         "type": "github"
       },
       "original": {
@@ -515,43 +514,6 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils-plus": {
-      "inputs": {
-        "flake-utils": "flake-utils_5"
-      },
-      "locked": {
-        "lastModified": 1715533576,
-        "narHash": "sha256-fT4ppWeCJ0uR300EH3i7kmgRZnAVxrH+XtK09jQWihk=",
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
         "systems": [
           "mac-app-util",
           "systems"
@@ -570,9 +532,46 @@
         "type": "indirect"
       }
     },
+    "flake-utils-plus": {
+      "inputs": {
+        "flake-utils": "flake-utils_4"
+      },
+      "locked": {
+        "lastModified": 1715533576,
+        "narHash": "sha256-fT4ppWeCJ0uR300EH3i7kmgRZnAVxrH+XtK09jQWihk=",
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -591,24 +590,6 @@
     "flake-utils_4": {
       "inputs": {
         "systems": "systems_7"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -685,30 +666,6 @@
         "type": "github"
       }
     },
-    "gomod2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "dank-material-shell",
-          "dms-cli",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1756047880,
-        "narHash": "sha256-JeuGh9kA1SPL70fnvpLxkIkCWpTjtoPaus3jzvdna0k=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "47d628dc3b506bd28632e47280c6b89d3496909d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "v1.7.0",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -737,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762025346,
-        "narHash": "sha256-6KR4dsNfA3Pqm6uT8j7aKjWydP/KXFqZUhOfMlfP+1E=",
+        "lastModified": 1762964643,
+        "narHash": "sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH+PEupBJqM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87044c57222fb485974062e2dd557e7b8abd8fff",
+        "rev": "827f2a23373a774a8805f84ca5344654c31f354b",
         "type": "github"
       },
       "original": {
@@ -819,11 +776,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760445448,
-        "narHash": "sha256-fXGjL6dw31FPFRrmIemzGiNSlfvEJTJNsmadZi+qNhI=",
+        "lastModified": 1762462052,
+        "narHash": "sha256-6roLYzcDf4V38RUMSqycsOwAnqfodL6BmhRkUtwIgdA=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "50fb9f069219f338a11cf0bcccb9e58357d67757",
+        "rev": "ffc999d980c7b3bca85d3ebd0a9fbadf984a8162",
         "type": "github"
       },
       "original": {
@@ -837,8 +794,8 @@
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
         "hyprgraphics": "hyprgraphics",
+        "hyprland-guiutils": "hyprland-guiutils",
         "hyprland-protocols": "hyprland-protocols",
-        "hyprland-qtutils": "hyprland-qtutils",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -846,20 +803,66 @@
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems_2",
+        "systems": "systems",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1761869718,
-        "narHash": "sha256-jLfwwlPGpnGRAtVDyoGj9FgH2D9hWwyEu0yHkflG2EI=",
+        "lastModified": 1762901961,
+        "narHash": "sha256-Oh7zDVRVW12nTiJD43UeuhqTox4c9vJCKnGIHHDbdic=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "8e9add2afda58d233a75e4c5ce8503b24fa59ceb",
+        "rev": "308226a4fc2c9b63fa19894d5f85e79e05d75e03",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
+        "type": "github"
+      }
+    },
+    "hyprland-guiutils": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprtoolkit": "hyprtoolkit",
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762755186,
+        "narHash": "sha256-ZjjETUHtoEhVN7JI1Cbt3p/KcXpK8ZQaPHx7UkG1OgA=",
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
+        "rev": "66356e20a8ed348aa49c1b9ceace786e224225b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
         "type": "github"
       }
     },
@@ -879,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761824067,
-        "narHash": "sha256-dB27qZRH2X5h2KM99UBYmksxb2ly2EGp5eSznTzRDe0=",
+        "lastModified": 1762893684,
+        "narHash": "sha256-YzNJ1S+ZnTsuz9xyi5HfR2VL+rqXgmqD+SU/OqCH5RM=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "7a07883c4d3e7ec6726862586483ea119e20eb0f",
+        "rev": "be3cbf60b4b6a90c6e0d947e1e8cf791062b81fb",
         "type": "github"
       },
       "original": {
@@ -917,74 +920,6 @@
         "type": "github"
       }
     },
-    "hyprland-qt-support": {
-      "inputs": {
-        "hyprlang": [
-          "hyprland",
-          "hyprland-qtutils",
-          "hyprlang"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "hyprland-qtutils",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "hyprland-qtutils",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749154592,
-        "narHash": "sha256-DO7z5CeT/ddSGDEnK9mAXm1qlGL47L3VAHLlLXoCjhE=",
-        "owner": "hyprwm",
-        "repo": "hyprland-qt-support",
-        "rev": "4c8053c3c888138a30c3a6c45c2e45f5484f2074",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-qt-support",
-        "type": "github"
-      }
-    },
-    "hyprland-qtutils": {
-      "inputs": {
-        "hyprland-qt-support": "hyprland-qt-support",
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprland-qtutils",
-          "hyprlang",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1759080228,
-        "narHash": "sha256-RgDoAja0T1hnF0pTc56xPfLfFOO8Utol2iITwYbUhTk=",
-        "owner": "hyprwm",
-        "repo": "hyprland-qtutils",
-        "rev": "629b15c19fa4082e4ce6be09fdb89e8c3312aed7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-qtutils",
-        "type": "github"
-      }
-    },
     "hyprlang": {
       "inputs": {
         "hyprutils": [
@@ -1014,6 +949,58 @@
         "type": "github"
       }
     },
+    "hyprtoolkit": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "hyprland-guiutils",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "hyprland-guiutils",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "hyprland-guiutils",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762463729,
+        "narHash": "sha256-2fYkU/mdz8WKY3dkDPlE/j6hTxIwqultsx4gMMsMns0=",
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "rev": "88483bdee5329ec985f0c8f834c519cd18cfe532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "type": "github"
+      }
+    },
     "hyprutils": {
       "inputs": {
         "nixpkgs": [
@@ -1026,11 +1013,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759619523,
-        "narHash": "sha256-r1ed7AR2ZEb2U8gy321/Xcp1ho2tzn+gG1te/Wxsj1A=",
+        "lastModified": 1762387740,
+        "narHash": "sha256-gQ9zJ+pUI4o+Gh4Z6jhJll7jjCSwi8ZqJIhCE2oqwhQ=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "3df7bde01efb3a3e8e678d1155f2aa3f19e177ef",
+        "rev": "926689ddb9c0a8787e58c02c765a62e32d63d1f7",
         "type": "github"
       },
       "original": {
@@ -1157,9 +1144,9 @@
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_4",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -1261,11 +1248,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1762022256,
-        "narHash": "sha256-UCaL2aD2GTk03W2ASxvt7ChKUXzRk6qbR8+e/Rjr6Mo=",
+        "lastModified": 1762938849,
+        "narHash": "sha256-ltM04Wy+vMm/EAwhGTl2BYjCgF+Kq4lltpDH9NEh264=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "dc61e1e639690d8ddccd5160aa11fb73cccfcf96",
+        "rev": "ea9b76cfa921d42a7502260b2d1296798089dfe6",
         "type": "github"
       },
       "original": {
@@ -1294,11 +1281,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1761721311,
-        "narHash": "sha256-fXBALdA4CKAYslcuamjzQZLUTCNBIKWybj+/2rwe3Z0=",
+        "lastModified": 1762881062,
+        "narHash": "sha256-j0Gxopn4jGYQae/90V2v4u4+Ec+gFLq3UbSaGfczpOM=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "6e8fd153395036c2daa7c214695ed9baf2409a2e",
+        "rev": "5b77107161c504376b962107913bf74b575703e7",
         "type": "github"
       },
       "original": {
@@ -1329,11 +1316,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1761962248,
-        "narHash": "sha256-tJROzIa21Ser5k12Hvd1W2M5ZQ4DiqROE3+c54zBbLk=",
+        "lastModified": 1762826226,
+        "narHash": "sha256-M4rbwlO4peCHRvA+WNYCmg8je4YBF7kSY9tG+p1kEKo=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "537f1d446238a6bb490e1765d39938166f1fb446",
+        "rev": "eefca17cb40462878ee1c46ac6910b2ec21adaa8",
         "type": "github"
       },
       "original": {
@@ -1344,17 +1331,17 @@
     },
     "nixgl": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1752054764,
-        "narHash": "sha256-Ob/HuUhANoDs+nvYqyTKrkcPXf4ZgXoqMTQoCK0RFgQ=",
+        "lastModified": 1762090880,
+        "narHash": "sha256-fbRQzIGPkjZa83MowjbD2ALaJf9y6KMDdJBQMKFeY/8=",
         "owner": "nix-community",
         "repo": "nixGL",
-        "rev": "a8e1ce7d49a149ed70df676785b07f63288f53c5",
+        "rev": "b6105297e6f0cd041670c3e8628394d4ee247ed5",
         "type": "github"
       },
       "original": {
@@ -1396,11 +1383,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -1426,11 +1413,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1761468971,
-        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
+        "lastModified": 1762756533,
+        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
+        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
         "type": "github"
       },
       "original": {
@@ -1442,11 +1429,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1761907660,
-        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
+        "lastModified": 1762844143,
+        "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
+        "rev": "9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4",
         "type": "github"
       },
       "original": {
@@ -1474,11 +1461,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1761349956,
-        "narHash": "sha256-tH3wHnOJms+U4k/rK2Nn1RfBrhffX92jLP/2VndSn0w=",
+        "lastModified": 1762361079,
+        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02f2cb8e0feb4596d20cc52fda73ccee960e3538",
+        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
         "type": "github"
       },
       "original": {
@@ -1490,11 +1477,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "lastModified": 1762756533,
+        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
         "type": "github"
       },
       "original": {
@@ -1561,7 +1548,7 @@
           "nvim-config",
           "nixpkgs"
         ],
-        "systems": "systems_6"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1762355423,
@@ -1635,11 +1622,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760663237,
-        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
+        "lastModified": 1762441963,
+        "narHash": "sha256-j+rNQ119ffYUkYt2YYS6rnd6Jh/crMZmbqpkGLXaEt0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
+        "rev": "8e7576e79b88c16d7ee3bbd112c8d90070832885",
         "type": "github"
       },
       "original": {
@@ -1741,7 +1728,7 @@
     },
     "rust-system-scripts": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1823,11 +1810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760998189,
-        "narHash": "sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY=",
+        "lastModified": 1762812535,
+        "narHash": "sha256-A91a+K0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb+s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5a7d18b5c55642df5c432aadb757140edfeb70b3",
+        "rev": "d75e4f89e58fdda39e4809f8c52013caa22483b7",
         "type": "github"
       },
       "original": {
@@ -1837,21 +1824,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
@@ -1866,7 +1838,7 @@
         "type": "github"
       }
     },
-    "systems_3": {
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1881,7 +1853,7 @@
         "type": "github"
       }
     },
-    "systems_4": {
+    "systems_3": {
       "locked": {
         "lastModified": 1689347925,
         "narHash": "sha256-ozenz5bFe1UUqOn7f60HRmgc01BgTGIKZ4Xl+HbocGQ=",
@@ -1893,6 +1865,21 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-darwin",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -1927,21 +1914,6 @@
       }
     },
     "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2008,7 +1980,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -2052,11 +2024,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760713634,
-        "narHash": "sha256-5HXelmz2x/uO26lvW7MudnadbAfoBnve4tRBiDVLtOM=",
+        "lastModified": 1761431178,
+        "narHash": "sha256-xzjC1CV3+wpUQKNF+GnadnkeGUCJX+vgaWIZsnz9tzI=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "753bbbdf6a052994da94062e5b753288cef28dfb",
+        "rev": "4b8801228ff958d028f588f0c2b911dbf32297f9",
         "type": "github"
       },
       "original": {
@@ -2085,11 +2057,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1761622056,
-        "narHash": "sha256-fBrUszJXmB4MY+wf3QsCnqWHcz7u7fLq0QMAWCltIQg=",
+        "lastModified": 1762747449,
+        "narHash": "sha256-Z1TKiux8K09a93w4PFDFsj8HFugXNy3iCC3Z8MpR5Rk=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "0728d59ff6463a502e001fb090f6eb92dbc04756",
+        "rev": "6338574bc5c036487486acde264f38f39ea15fad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/ca226e98c2d30c753c9fb000e19aded51bb78781?narHash=sha256-FFfvV6DHqTvHPOc9r6Bt57rt57fek4sArQ4MgvYQo7M%3D' (2025-11-01)
  → 'github:AvengeMedia/DankMaterialShell/6013c994a66ff6e8b8f05c9465c60afda906e8cb?narHash=sha256-Q1sscRok5XFc1zgET2QonPNAq8ac5hurDq5zKZPJ2Y8%3D' (2025-11-12)
• Updated input 'dank-material-shell/dgop':
    'github:AvengeMedia/dgop/95acdfce2d323e28fa8f5a4f345160962034f2b5?narHash=sha256-7CeGZM/Z/5Qt3AYByCRohGYGR1MRuXYzTTbkV/JxyAs%3D' (2025-10-12)
  → 'github:AvengeMedia/dgop/6cf638dde818f9f8a2e26d0243179c43cb3458d7?narHash=sha256-QhzRn7pYN35IFpKjjxJAj3GPJECuC%2BVLhoGem3ezycc%3D' (2025-11-06)
• Updated input 'dank-material-shell/dms-cli':
    'github:AvengeMedia/danklinux/d42b58f35c129e893819742746f11ef7e82be56f?narHash=sha256-51m0k2BN6EjUKZI/tRs563HqGPhsM639kwuXcqxuniM%3D' (2025-10-22)
  → 'github:AvengeMedia/danklinux/050cf28a2963a7698ed4759736fe5fe77eee7cc2?narHash=sha256-oGLH5Gje/p2Hc1kO3m8P5eAZ7JldBI30EmwzEET4cNU%3D' (2025-11-07)
• Removed input 'dank-material-shell/dms-cli/gomod2nix'
• Removed input 'dank-material-shell/dms-cli/gomod2nix/flake-utils'
• Removed input 'dank-material-shell/dms-cli/gomod2nix/flake-utils/systems'
• Removed input 'dank-material-shell/dms-cli/gomod2nix/nixpkgs'
• Updated input 'darwin':
    'github:LnL7/nix-darwin/000eadb231812ad6ea6aebd7526974aaf4e79355?narHash=sha256-4XifSIHfpJKcCf5bZZRhj8C4aCpjNBaE3kXr02s4rHU%3D' (2025-10-03)
  → 'github:LnL7/nix-darwin/d76299b2cd01837c4c271a7b5186e3d5d8ebd126?narHash=sha256-4hpBE7bGd24SfD28rzMdUGXsLsNEYxCCrTipFdoqoNM%3D' (2025-11-12)
• Updated input 'dms-emoji-launcher':
    'github:devnullvoid/dms-emoji-launcher/79bdec809481a2d65d18b02004a5d0195167d22c?narHash=sha256-Jpz/s6ol257xn0ERNsitEJB4lPhy%2BlJ0mf3InInP6i8%3D' (2025-10-27)
  → 'github:devnullvoid/dms-emoji-launcher/2951ec7f823c983c11b6b231403581a386a7c9f6?narHash=sha256-aub5pXRMlMs7dxiv5P%2B/Rz/dA4weojr%2BSGZAItmbOvo%3D' (2025-11-09)
• Updated input 'dms-official-plugins':
    'github:AvengeMedia/dms-plugins/43ec46372c728ed416b37f66886c2a0e5aff026c?narHash=sha256-piEPE5GOMKyM%2By4qpfMyRlIk4GQjVxqzF5BtxOJ9UZ8%3D' (2025-10-26)
  → 'github:AvengeMedia/dms-plugins/2b2353cace2bb63c3559f32576c028d52498c86c?narHash=sha256-qGseA9QsSXEffTKOvLjJDgW0V5Ej39Mc%2BfcMP2dcNCM%3D' (2025-11-10)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/aecae658b04384b2f87249c6b93fdbfd97ef249d?dir=pkgs/firefox-addons&narHash=sha256-YqUB0AYD4KbeqvSZqPhXhHBj3mLKTyuYrofyRgG3%2BXc%3D' (2025-11-01)
  → 'gitlab:rycee/nur-expressions/8cd76837f50debe28b51820adb00b522df8ade91?dir=pkgs/firefox-addons&narHash=sha256-VuUg2EP2Y0QrDTsDP6/3kN3Hurn6HfyMW3rGzdruhW8%3D' (2025-11-12)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/87044c57222fb485974062e2dd557e7b8abd8fff?narHash=sha256-6KR4dsNfA3Pqm6uT8j7aKjWydP/KXFqZUhOfMlfP%2B1E%3D' (2025-11-01)
  → 'github:nix-community/home-manager/827f2a23373a774a8805f84ca5344654c31f354b?narHash=sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH%2BPEupBJqM%3D' (2025-11-12)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/8e9add2afda58d233a75e4c5ce8503b24fa59ceb?narHash=sha256-jLfwwlPGpnGRAtVDyoGj9FgH2D9hWwyEu0yHkflG2EI%3D' (2025-10-31)
  → 'github:hyprwm/Hyprland/308226a4fc2c9b63fa19894d5f85e79e05d75e03?narHash=sha256-Oh7zDVRVW12nTiJD43UeuhqTox4c9vJCKnGIHHDbdic%3D' (2025-11-11)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/1826a9923881320306231b1c2090379ebf9fa4f8?narHash=sha256-8jf/3ZCi%2BB7zYpIyV04%2B3wm72BD7Z801IlOzsOACR7I%3D' (2025-10-10)
  → 'github:hyprwm/aquamarine/6d0b3567584691bf9d8fedb5d0093309e2f979c7?narHash=sha256-qwd/xdoOya1m8FENle%2B4hWnydCtlXUWLAW/Auk6WL7s%3D' (2025-11-05)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/50fb9f069219f338a11cf0bcccb9e58357d67757?narHash=sha256-fXGjL6dw31FPFRrmIemzGiNSlfvEJTJNsmadZi%2BqNhI%3D' (2025-10-14)
  → 'github:hyprwm/hyprgraphics/ffc999d980c7b3bca85d3ebd0a9fbadf984a8162?narHash=sha256-6roLYzcDf4V38RUMSqycsOwAnqfodL6BmhRkUtwIgdA%3D' (2025-11-06)
• Added input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/66356e20a8ed348aa49c1b9ceace786e224225b3?narHash=sha256-ZjjETUHtoEhVN7JI1Cbt3p/KcXpK8ZQaPHx7UkG1OgA%3D' (2025-11-10)
• Added input 'hyprland/hyprland-guiutils/aquamarine':
    follows 'hyprland/aquamarine'
• Added input 'hyprland/hyprland-guiutils/hyprgraphics':
    follows 'hyprland/hyprgraphics'
• Added input 'hyprland/hyprland-guiutils/hyprlang':
    follows 'hyprland/hyprlang'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit':
    'github:hyprwm/hyprtoolkit/88483bdee5329ec985f0c8f834c519cd18cfe532?narHash=sha256-2fYkU/mdz8WKY3dkDPlE/j6hTxIwqultsx4gMMsMns0%3D' (2025-11-06)
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/aquamarine':
    follows 'hyprland/hyprland-guiutils/aquamarine'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/hyprgraphics':
    follows 'hyprland/hyprland-guiutils/hyprgraphics'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/hyprlang':
    follows 'hyprland/hyprland-guiutils/hyprlang'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/hyprutils':
    follows 'hyprland/hyprland-guiutils/hyprutils'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/hyprwayland-scanner':
    follows 'hyprland/hyprland-guiutils/hyprwayland-scanner'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/nixpkgs':
    follows 'hyprland/hyprland-guiutils/nixpkgs'
• Added input 'hyprland/hyprland-guiutils/hyprtoolkit/systems':
    follows 'hyprland/hyprland-guiutils/systems'
• Added input 'hyprland/hyprland-guiutils/hyprutils':
    follows 'hyprland/hyprutils'
• Added input 'hyprland/hyprland-guiutils/hyprwayland-scanner':
    follows 'hyprland/hyprwayland-scanner'
• Added input 'hyprland/hyprland-guiutils/nixpkgs':
    follows 'hyprland/nixpkgs'
• Added input 'hyprland/hyprland-guiutils/systems':
    follows 'hyprland/systems'
• Removed input 'hyprland/hyprland-qtutils'
• Removed input 'hyprland/hyprland-qtutils/hyprland-qt-support'
• Removed input 'hyprland/hyprland-qtutils/hyprland-qt-support/hyprlang'
• Removed input 'hyprland/hyprland-qtutils/hyprland-qt-support/nixpkgs'
• Removed input 'hyprland/hyprland-qtutils/hyprland-qt-support/systems'
• Removed input 'hyprland/hyprland-qtutils/hyprlang'
• Removed input 'hyprland/hyprland-qtutils/hyprutils'
• Removed input 'hyprland/hyprland-qtutils/nixpkgs'
• Removed input 'hyprland/hyprland-qtutils/systems'
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/3df7bde01efb3a3e8e678d1155f2aa3f19e177ef?narHash=sha256-r1ed7AR2ZEb2U8gy321/Xcp1ho2tzn%2BgG1te/Wxsj1A%3D' (2025-10-04)
  → 'github:hyprwm/hyprutils/926689ddb9c0a8787e58c02c765a62e32d63d1f7?narHash=sha256-gQ9zJ%2BpUI4o%2BGh4Z6jhJll7jjCSwi8ZqJIhCE2oqwhQ%3D' (2025-11-06)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37?narHash=sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc%3D' (2025-10-17)
  → 'github:cachix/git-hooks.nix/8e7576e79b88c16d7ee3bbd112c8d90070832885?narHash=sha256-j%2BrNQ119ffYUkYt2YYS6rnd6Jh/crMZmbqpkGLXaEt0%3D' (2025-11-06)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/753bbbdf6a052994da94062e5b753288cef28dfb?narHash=sha256-5HXelmz2x/uO26lvW7MudnadbAfoBnve4tRBiDVLtOM%3D' (2025-10-17)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/4b8801228ff958d028f588f0c2b911dbf32297f9?narHash=sha256-xzjC1CV3%2BwpUQKNF%2BGnadnkeGUCJX%2BvgaWIZsnz9tzI%3D' (2025-10-25)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/7a07883c4d3e7ec6726862586483ea119e20eb0f?narHash=sha256-dB27qZRH2X5h2KM99UBYmksxb2ly2EGp5eSznTzRDe0%3D' (2025-10-30)
  → 'github:hyprwm/hyprland-plugins/be3cbf60b4b6a90c6e0d947e1e8cf791062b81fb?narHash=sha256-YzNJ1S%2BZnTsuz9xyi5HfR2VL%2BrqXgmqD%2BSU/OqCH5RM%3D' (2025-11-11)
• Updated input 'niri':
    'github:sodiboo/niri-flake/dc61e1e639690d8ddccd5160aa11fb73cccfcf96?narHash=sha256-UCaL2aD2GTk03W2ASxvt7ChKUXzRk6qbR8%2Be/Rjr6Mo%3D' (2025-11-01)
  → 'github:sodiboo/niri-flake/ea9b76cfa921d42a7502260b2d1296798089dfe6?narHash=sha256-ltM04Wy%2BvMm/EAwhGTl2BYjCgF%2BKq4lltpDH9NEh264%3D' (2025-11-12)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/6e8fd153395036c2daa7c214695ed9baf2409a2e?narHash=sha256-fXBALdA4CKAYslcuamjzQZLUTCNBIKWybj%2B/2rwe3Z0%3D' (2025-10-29)
  → 'github:YaLTeR/niri/5b77107161c504376b962107913bf74b575703e7?narHash=sha256-j0Gxopn4jGYQae/90V2v4u4%2BEc%2BgFLq3UbSaGfczpOM%3D' (2025-11-11)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/78e34d1667d32d8a0ffc3eba4591ff256e80576e?narHash=sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8%3D' (2025-10-26)
  → 'github:NixOS/nixpkgs/c2448301fb856e351aab33e64c33a3fc8bcf637d?narHash=sha256-HiRDeUOD1VLklHeOmaKDzf%2B8Hb7vSWPVFcWwaTrpm%2BU%3D' (2025-11-10)
• Updated input 'niri/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/0728d59ff6463a502e001fb090f6eb92dbc04756?narHash=sha256-fBrUszJXmB4MY%2Bwf3QsCnqWHcz7u7fLq0QMAWCltIQg%3D' (2025-10-28)
  → 'github:Supreeeme/xwayland-satellite/6338574bc5c036487486acde264f38f39ea15fad?narHash=sha256-Z1TKiux8K09a93w4PFDFsj8HFugXNy3iCC3Z8MpR5Rk%3D' (2025-11-10)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/537f1d446238a6bb490e1765d39938166f1fb446?narHash=sha256-tJROzIa21Ser5k12Hvd1W2M5ZQ4DiqROE3%2Bc54zBbLk%3D' (2025-11-01)
  → 'github:fufexan/nix-gaming/eefca17cb40462878ee1c46ac6910b2ec21adaa8?narHash=sha256-M4rbwlO4peCHRvA%2BWNYCmg8je4YBF7kSY9tG%2Bp1kEKo%3D' (2025-11-11)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/864599284fc7c0ba6357ed89ed5e2cd5040f0c04?narHash=sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4%3D' (2025-10-20)
  → 'github:hercules-ci/flake-parts/26d05891e14c88eb4a5d5bee659c0db5afb609d8?narHash=sha256-xxdepIcb39UJ94%2BYydGP221rjnpkDZUlykKuF54PsqI%3D' (2025-11-06)
• Updated input 'nix-gaming/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/a73b9c743612e4244d865a2fdee11865283c04e6?narHash=sha256-x2rJ%2BOvzq0sCMpgfgGaaqgBSwY%2BLST%2BWbZ6TytnT9Rk%3D' (2025-08-10)
  → 'github:nix-community/nixpkgs.lib/719359f4562934ae99f5443f20aa06c2ffff91fc?narHash=sha256-b0yj6kfvO8ApcSE%2BQmA6mUfu8IYG6/uU28OFn4PaC8M%3D' (2025-10-29)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/02f2cb8e0feb4596d20cc52fda73ccee960e3538?narHash=sha256-tH3wHnOJms%2BU4k/rK2Nn1RfBrhffX92jLP/2VndSn0w%3D' (2025-10-24)
  → 'github:NixOS/nixpkgs/ffcdcf99d65c61956d882df249a9be53e5902ea5?narHash=sha256-lz718rr1BDpZBYk7%2BG8cE6wee3PiBUpn8aomG/vLLiY%3D' (2025-11-05)
• Updated input 'nixgl':
    'github:nix-community/nixGL/a8e1ce7d49a149ed70df676785b07f63288f53c5?narHash=sha256-Ob/HuUhANoDs%2BnvYqyTKrkcPXf4ZgXoqMTQoCK0RFgQ%3D' (2025-07-09)
  → 'github:nix-community/nixGL/b6105297e6f0cd041670c3e8628394d4ee247ed5?narHash=sha256-fbRQzIGPkjZa83MowjbD2ALaJf9y6KMDdJBQMKFeY/8%3D' (2025-11-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/daf6dc47aa4b44791372d6139ab7b25269184d55?narHash=sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8%2BON/0Yy8%2Ba5vsDU%3D' (2025-10-27)
  → 'github:NixOS/nixpkgs/c2448301fb856e351aab33e64c33a3fc8bcf637d?narHash=sha256-HiRDeUOD1VLklHeOmaKDzf%2B8Hb7vSWPVFcWwaTrpm%2BU%3D' (2025-11-10)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15?narHash=sha256-kJ8lIZsiPOmbkJypG%2BB5sReDXSD1KGu2VEPNqhRa/ew%3D' (2025-10-31)
  → 'github:NixOS/nixpkgs/9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4?narHash=sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI%3D' (2025-11-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5a7d18b5c55642df5c432aadb757140edfeb70b3?narHash=sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY%3D' (2025-10-20)
  → 'github:Mic92/sops-nix/d75e4f89e58fdda39e4809f8c52013caa22483b7?narHash=sha256-A91a%2BK0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb%2Bs%3D' (2025-11-10)```