### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,17 +178,16 @@
     "dank-material-shell": {
       "inputs": {
         "dgop": "dgop",
-        "dms-cli": "dms-cli",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1762984947,
-        "narHash": "sha256-Q1sscRok5XFc1zgET2QonPNAq8ac5hurDq5zKZPJ2Y8=",
+        "lastModified": 1763180774,
+        "narHash": "sha256-0pAfeIDseUKd22XVrH6V9qXD8kD1yxJHG+hiD4/xIVA=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "6013c994a66ff6e8b8f05c9465c60afda906e8cb",
+        "rev": "217037c2ae011d131a0a7ecefd23b6ad99ac4f1b",
         "type": "github"
       },
       "original": {
@@ -255,27 +254,6 @@
         "type": "github"
       }
     },
-    "dms-cli": {
-      "inputs": {
-        "nixpkgs": [
-          "dank-material-shell",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762491516,
-        "narHash": "sha256-oGLH5Gje/p2Hc1kO3m8P5eAZ7JldBI30EmwzEET4cNU=",
-        "owner": "AvengeMedia",
-        "repo": "danklinux",
-        "rev": "050cf28a2963a7698ed4759736fe5fe77eee7cc2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "AvengeMedia",
-        "repo": "danklinux",
-        "type": "github"
-      }
-    },
     "dms-emoji-launcher": {
       "flake": false,
       "locked": {
@@ -332,11 +310,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1762920261,
-        "narHash": "sha256-VuUg2EP2Y0QrDTsDP6/3kN3Hurn6HfyMW3rGzdruhW8=",
+        "lastModified": 1763179480,
+        "narHash": "sha256-bsHnmNm/2ev8XNzKibc6swU5zM2bB3/v3UbtlQyS1dA=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "8cd76837f50debe28b51820adb00b522df8ade91",
+        "rev": "6831e9334d8efd7b1f9b570be748e7cf0173f6b7",
         "type": "gitlab"
       },
       "original": {
@@ -694,11 +672,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762964643,
-        "narHash": "sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH+PEupBJqM=",
+        "lastModified": 1763198244,
+        "narHash": "sha256-oLugbe2pJv39BjWg7kAljn6vUxjVr/ArkITDX8fFd2Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "827f2a23373a774a8805f84ca5344654c31f354b",
+        "rev": "c3bc79be5ee97455262c6c677bbf065eed07948c",
         "type": "github"
       },
       "original": {
@@ -807,11 +785,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1762901961,
-        "narHash": "sha256-Oh7zDVRVW12nTiJD43UeuhqTox4c9vJCKnGIHHDbdic=",
+        "lastModified": 1763071594,
+        "narHash": "sha256-s5FF0rQE6UIBAUfqk5ZqGedU3bhW0OvXfmz5lzJGurY=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "308226a4fc2c9b63fa19894d5f85e79e05d75e03",
+        "rev": "43527d363472b52f17dd9f9f4f87ec25cbf8a399",
         "type": "github"
       },
       "original": {
@@ -882,11 +860,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762893684,
-        "narHash": "sha256-YzNJ1S+ZnTsuz9xyi5HfR2VL+rqXgmqD+SU/OqCH5RM=",
+        "lastModified": 1762989208,
+        "narHash": "sha256-NBTbKW0MVIMFCjAqeoJWkg5iUucAZ9jS4Lbyax6rIBE=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "be3cbf60b4b6a90c6e0d947e1e8cf791062b81fb",
+        "rev": "befb2670803cf7c1b9f0323449c8d9ccdaa485e2",
         "type": "github"
       },
       "original": {
@@ -1248,11 +1226,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1762938849,
-        "narHash": "sha256-ltM04Wy+vMm/EAwhGTl2BYjCgF+Kq4lltpDH9NEh264=",
+        "lastModified": 1763126448,
+        "narHash": "sha256-LVYJJObvkWwR8QB/Srr6Rks+Fw2lYvnRNOH0etV9DM8=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "ea9b76cfa921d42a7502260b2d1296798089dfe6",
+        "rev": "add7bcf2925547e180cc2fe6d5f4b5e7c579d086",
         "type": "github"
       },
       "original": {
@@ -1281,11 +1259,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1762881062,
-        "narHash": "sha256-j0Gxopn4jGYQae/90V2v4u4+Ec+gFLq3UbSaGfczpOM=",
+        "lastModified": 1763014447,
+        "narHash": "sha256-nmu7S8J9IJKLQyIkSU8QWYHygrfw76NHGTkcr+bXMX0=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "5b77107161c504376b962107913bf74b575703e7",
+        "rev": "a52df533c4694b5ed0a04140af60fd26146df911",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1294,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1762826226,
-        "narHash": "sha256-M4rbwlO4peCHRvA+WNYCmg8je4YBF7kSY9tG+p1kEKo=",
+        "lastModified": 1763171532,
+        "narHash": "sha256-jWbp1mb+Vb2Z0oMQci859yDHULbDO57ISxLXG98DZHE=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "eefca17cb40462878ee1c46ac6910b2ec21adaa8",
+        "rev": "c03e4ab01b392652992985dfc3dea2f1d370f746",
         "type": "github"
       },
       "original": {
@@ -1413,11 +1391,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1763049705,
+        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
         "type": "github"
       },
       "original": {
@@ -1429,11 +1407,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762844143,
-        "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {
@@ -1477,11 +1455,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1763049705,
+        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
         "type": "github"
       },
       "original": {
@@ -1583,11 +1561,11 @@
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1762985120,
-        "narHash": "sha256-Zx0mPx5EEum+NqJBmlkcyg8wkIgN6d7V0a09gIc9gMs=",
+        "lastModified": 1763005151,
+        "narHash": "sha256-avJPxRT/4criRvyi8tJ8aaqbPqCAJgXSO7E2Xhi5EWM=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "6aea2d881bebf69754fbca1b33deb4852c7f4f19",
+        "rev": "4cb7f6054430e1eccca6d9a3b7ad3eef2dba684e",
         "type": "github"
       },
       "original": {
@@ -1642,11 +1620,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761897390,
-        "narHash": "sha256-er4gYrIoThYLjlsOMTysoRfn67d1Gci+ZpqDrtQxrA0=",
+        "lastModified": 1763202718,
+        "narHash": "sha256-EoVPa0OM7yJ0g47VTkD5yVn6MUcLJT0YsVASTb/OZuI=",
         "ref": "master",
-        "rev": "fc704e6b5d445899a1565955268c91942a4f263f",
-        "revCount": 700,
+        "rev": "0a36e3ed40bf2de41b76ac363bc1f98820473786",
+        "revCount": 702,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1810,11 +1788,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762812535,
+        "lastModified": 1763069729,
         "narHash": "sha256-A91a+K0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb+s=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d75e4f89e58fdda39e4809f8c52013caa22483b7",
+        "rev": "a2bcd1c25c1d29e22756ccae094032ab4ada2268",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/6013c994a66ff6e8b8f05c9465c60afda906e8cb?narHash=sha256-Q1sscRok5XFc1zgET2QonPNAq8ac5hurDq5zKZPJ2Y8%3D' (2025-11-12)
  → 'github:AvengeMedia/DankMaterialShell/217037c2ae011d131a0a7ecefd23b6ad99ac4f1b?narHash=sha256-0pAfeIDseUKd22XVrH6V9qXD8kD1yxJHG%2BhiD4/xIVA%3D' (2025-11-15)
• Removed input 'dank-material-shell/dms-cli'
• Removed input 'dank-material-shell/dms-cli/nixpkgs'
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/8cd76837f50debe28b51820adb00b522df8ade91?dir=pkgs/firefox-addons&narHash=sha256-VuUg2EP2Y0QrDTsDP6/3kN3Hurn6HfyMW3rGzdruhW8%3D' (2025-11-12)
  → 'gitlab:rycee/nur-expressions/6831e9334d8efd7b1f9b570be748e7cf0173f6b7?dir=pkgs/firefox-addons&narHash=sha256-bsHnmNm/2ev8XNzKibc6swU5zM2bB3/v3UbtlQyS1dA%3D' (2025-11-15)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/827f2a23373a774a8805f84ca5344654c31f354b?narHash=sha256-RYHN8O/Aja59XDji6WSJZPkJpYVUfpSkyH%2BPEupBJqM%3D' (2025-11-12)
  → 'github:nix-community/home-manager/c3bc79be5ee97455262c6c677bbf065eed07948c?narHash=sha256-oLugbe2pJv39BjWg7kAljn6vUxjVr/ArkITDX8fFd2Y%3D' (2025-11-15)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/308226a4fc2c9b63fa19894d5f85e79e05d75e03?narHash=sha256-Oh7zDVRVW12nTiJD43UeuhqTox4c9vJCKnGIHHDbdic%3D' (2025-11-11)
  → 'github:hyprwm/Hyprland/43527d363472b52f17dd9f9f4f87ec25cbf8a399?narHash=sha256-s5FF0rQE6UIBAUfqk5ZqGedU3bhW0OvXfmz5lzJGurY%3D' (2025-11-13)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/be3cbf60b4b6a90c6e0d947e1e8cf791062b81fb?narHash=sha256-YzNJ1S%2BZnTsuz9xyi5HfR2VL%2BrqXgmqD%2BSU/OqCH5RM%3D' (2025-11-11)
  → 'github:hyprwm/hyprland-plugins/befb2670803cf7c1b9f0323449c8d9ccdaa485e2?narHash=sha256-NBTbKW0MVIMFCjAqeoJWkg5iUucAZ9jS4Lbyax6rIBE%3D' (2025-11-12)
• Updated input 'niri':
    'github:sodiboo/niri-flake/ea9b76cfa921d42a7502260b2d1296798089dfe6?narHash=sha256-ltM04Wy%2BvMm/EAwhGTl2BYjCgF%2BKq4lltpDH9NEh264%3D' (2025-11-12)
  → 'github:sodiboo/niri-flake/add7bcf2925547e180cc2fe6d5f4b5e7c579d086?narHash=sha256-LVYJJObvkWwR8QB/Srr6Rks%2BFw2lYvnRNOH0etV9DM8%3D' (2025-11-14)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/5b77107161c504376b962107913bf74b575703e7?narHash=sha256-j0Gxopn4jGYQae/90V2v4u4%2BEc%2BgFLq3UbSaGfczpOM%3D' (2025-11-11)
  → 'github:YaLTeR/niri/a52df533c4694b5ed0a04140af60fd26146df911?narHash=sha256-nmu7S8J9IJKLQyIkSU8QWYHygrfw76NHGTkcr%2BbXMX0%3D' (2025-11-13)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/c2448301fb856e351aab33e64c33a3fc8bcf637d?narHash=sha256-HiRDeUOD1VLklHeOmaKDzf%2B8Hb7vSWPVFcWwaTrpm%2BU%3D' (2025-11-10)
  → 'github:NixOS/nixpkgs/3acb677ea67d4c6218f33de0db0955f116b7588c?narHash=sha256-A5LS0AJZ1yDPTa2fHxufZN%2B%2Bn8MCmtgrJDtxFxrH4S8%3D' (2025-11-13)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/eefca17cb40462878ee1c46ac6910b2ec21adaa8?narHash=sha256-M4rbwlO4peCHRvA%2BWNYCmg8je4YBF7kSY9tG%2Bp1kEKo%3D' (2025-11-11)
  → 'github:fufexan/nix-gaming/c03e4ab01b392652992985dfc3dea2f1d370f746?narHash=sha256-jWbp1mb%2BVb2Z0oMQci859yDHULbDO57ISxLXG98DZHE%3D' (2025-11-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c2448301fb856e351aab33e64c33a3fc8bcf637d?narHash=sha256-HiRDeUOD1VLklHeOmaKDzf%2B8Hb7vSWPVFcWwaTrpm%2BU%3D' (2025-11-10)
  → 'github:NixOS/nixpkgs/3acb677ea67d4c6218f33de0db0955f116b7588c?narHash=sha256-A5LS0AJZ1yDPTa2fHxufZN%2B%2Bn8MCmtgrJDtxFxrH4S8%3D' (2025-11-13)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4?narHash=sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI%3D' (2025-11-11)
  → 'github:NixOS/nixpkgs/c5ae371f1a6a7fd27823bc500d9390b38c05fa55?narHash=sha256-4PqRErxfe%2B2toFJFgcRKZ0UI9NSIOJa%2B7RXVtBhy4KE%3D' (2025-11-12)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/6aea2d881bebf69754fbca1b33deb4852c7f4f19?narHash=sha256-Zx0mPx5EEum%2BNqJBmlkcyg8wkIgN6d7V0a09gIc9gMs%3D' (2025-11-12)
  → 'github:derethil/nvim-config/4cb7f6054430e1eccca6d9a3b7ad3eef2dba684e?narHash=sha256-avJPxRT/4criRvyi8tJ8aaqbPqCAJgXSO7E2Xhi5EWM%3D' (2025-11-13)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=fc704e6b5d445899a1565955268c91942a4f263f' (2025-10-31)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=0a36e3ed40bf2de41b76ac363bc1f98820473786' (2025-11-15)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d75e4f89e58fdda39e4809f8c52013caa22483b7?narHash=sha256-A91a%2BK0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb%2Bs%3D' (2025-11-10)
  → 'github:Mic92/sops-nix/a2bcd1c25c1d29e22756ccae094032ab4ada2268?narHash=sha256-A91a%2BK0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb%2Bs%3D' (2025-11-13)```