### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,11 +206,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763180774,
-        "narHash": "sha256-0pAfeIDseUKd22XVrH6V9qXD8kD1yxJHG+hiD4/xIVA=",
+        "lastModified": 1763788986,
+        "narHash": "sha256-uYgLhTSxWs9IRpia5Hxd7AMCaE0plr0+QhWBf26h9V0=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "217037c2ae011d131a0a7ecefd23b6ad99ac4f1b",
+        "rev": "58bf1899410536c4244b9d44c243426dc1b2a2c9",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1763179480,
-        "narHash": "sha256-bsHnmNm/2ev8XNzKibc6swU5zM2bB3/v3UbtlQyS1dA=",
+        "lastModified": 1763784262,
+        "narHash": "sha256-bg+MOwWA4GgsHQ2QZQHCixIs0ouPHvN1EVAzMTELPiQ=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "6831e9334d8efd7b1f9b570be748e7cf0173f6b7",
+        "rev": "a717a95e58c8dfdb3d07797b97fdedc97697d65c",
         "type": "gitlab"
       },
       "original": {
@@ -438,11 +438,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762440070,
-        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
+        "lastModified": 1762980239,
+        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
+        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763198244,
-        "narHash": "sha256-oLugbe2pJv39BjWg7kAljn6vUxjVr/ArkITDX8fFd2Y=",
+        "lastModified": 1763748372,
+        "narHash": "sha256-AUc78Qv3sWir0hvbmfXoZ7Jzq9VVL97l+sP9Jgms+JU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c3bc79be5ee97455262c6c677bbf065eed07948c",
+        "rev": "d10a9b16b2a3ee28433f3d1c603f4e9f1fecb8e1",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1763071594,
-        "narHash": "sha256-s5FF0rQE6UIBAUfqk5ZqGedU3bhW0OvXfmz5lzJGurY=",
+        "lastModified": 1763750925,
+        "narHash": "sha256-Q5IO8VKW2fFHb6Ix6auy6SEMA6NS6pNeuefBai4+PHY=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "43527d363472b52f17dd9f9f4f87ec25cbf8a399",
+        "rev": "abb2f7ee6fc99c31b6fac05568f29c92b59565df",
         "type": "github"
       },
       "original": {
@@ -918,11 +918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762989208,
-        "narHash": "sha256-NBTbKW0MVIMFCjAqeoJWkg5iUucAZ9jS4Lbyax6rIBE=",
+        "lastModified": 1763732618,
+        "narHash": "sha256-hvElpSNHbYSBsn/GoJV0RgAecpn3vcC5kJso34XqwJw=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "befb2670803cf7c1b9f0323449c8d9ccdaa485e2",
+        "rev": "57961d69ad9725986290c8c0f2b0d118b645daee",
         "type": "github"
       },
       "original": {
@@ -972,11 +972,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758927902,
-        "narHash": "sha256-LZgMds7M94+vuMql2bERQ6LiFFdhgsEFezE4Vn+Ys3A=",
+        "lastModified": 1763254292,
+        "narHash": "sha256-JNgz3Fz2KMzkT7aR72wsgu/xNeJB//LSmdilh8Z/Zao=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "4dafa28d4f79877d67a7d1a654cddccf8ebf15da",
+        "rev": "deea98d5b61d066bdc7a68163edd2c4bd28d3a6b",
         "type": "github"
       },
       "original": {
@@ -1049,11 +1049,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762387740,
-        "narHash": "sha256-gQ9zJ+pUI4o+Gh4Z6jhJll7jjCSwi8ZqJIhCE2oqwhQ=",
+        "lastModified": 1763323331,
+        "narHash": "sha256-+Z0OfCo1MS8/aIutSAW5aJR9zTae1wz9kcJYMgpwN6M=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "926689ddb9c0a8787e58c02c765a62e32d63d1f7",
+        "rev": "0c6411851cc779d551edc89b83966696201611aa",
         "type": "github"
       },
       "original": {
@@ -1306,11 +1306,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1763126448,
-        "narHash": "sha256-LVYJJObvkWwR8QB/Srr6Rks+Fw2lYvnRNOH0etV9DM8=",
+        "lastModified": 1763804463,
+        "narHash": "sha256-iPSL5ONtFDbocfEGCgR8Ik72VRDiS4Nuu7i27kmJ0jQ=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "add7bcf2925547e180cc2fe6d5f4b5e7c579d086",
+        "rev": "960b925b8860e2c7b0149a530041358aa3201fbf",
         "type": "github"
       },
       "original": {
@@ -1339,11 +1339,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1763014447,
-        "narHash": "sha256-nmu7S8J9IJKLQyIkSU8QWYHygrfw76NHGTkcr+bXMX0=",
+        "lastModified": 1763799335,
+        "narHash": "sha256-b6hgDHjrLgTp4Y8DD5woGChg0R+yH16m0ZWVi9BhjrA=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "a52df533c4694b5ed0a04140af60fd26146df911",
+        "rev": "cfc01b895c0c7cbb9692852488675cc46693bd2a",
         "type": "github"
       },
       "original": {
@@ -1374,11 +1374,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1763171532,
-        "narHash": "sha256-jWbp1mb+Vb2Z0oMQci859yDHULbDO57ISxLXG98DZHE=",
+        "lastModified": 1763776301,
+        "narHash": "sha256-FD8dx7R543AFOnYX2sRwTGA4mcC1gVQ92D1RHzz6Cs4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "c03e4ab01b392652992985dfc3dea2f1d370f746",
+        "rev": "c34f0eefe470a12e486ee56d65e5e21a55161028",
         "type": "github"
       },
       "original": {
@@ -1494,11 +1494,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1763049705,
-        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
+        "lastModified": 1763622513,
+        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
+        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
         "type": "github"
       },
       "original": {
@@ -1510,11 +1510,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1763421233,
+        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
         "type": "github"
       },
       "original": {
@@ -1558,11 +1558,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1762361079,
-        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
+        "lastModified": 1763312402,
+        "narHash": "sha256-3YJkOBrFpmcusnh7i8GXXEyh7qZG/8F5z5+717550Hk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
+        "rev": "85a6c4a07faa12aaccd81b36ba9bfc2bec974fa1",
         "type": "github"
       },
       "original": {
@@ -1574,11 +1574,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1763049705,
-        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
+        "lastModified": 1763622513,
+        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
+        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
         "type": "github"
       },
       "original": {
@@ -1719,11 +1719,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762441963,
-        "narHash": "sha256-j+rNQ119ffYUkYt2YYS6rnd6Jh/crMZmbqpkGLXaEt0=",
+        "lastModified": 1763319842,
+        "narHash": "sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8e7576e79b88c16d7ee3bbd112c8d90070832885",
+        "rev": "7275fa67fbbb75891c16d9dee7d88e58aea2d761",
         "type": "github"
       },
       "original": {
@@ -1739,11 +1739,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763202718,
-        "narHash": "sha256-EoVPa0OM7yJ0g47VTkD5yVn6MUcLJT0YsVASTb/OZuI=",
+        "lastModified": 1763629934,
+        "narHash": "sha256-jWz10RbNAyylJbH4cUTLS/CsDjkd8gxfT8OsIgQIgEg=",
         "ref": "master",
-        "rev": "0a36e3ed40bf2de41b76ac363bc1f98820473786",
-        "revCount": 702,
+        "rev": "ed036d514b0fdbce03158a0b331305be166f4555",
+        "revCount": 708,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1929,11 +1929,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763069729,
-        "narHash": "sha256-A91a+K0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb+s=",
+        "lastModified": 1763607916,
+        "narHash": "sha256-VefBA1JWRXM929mBAFohFUtQJLUnEwZ2vmYUNkFnSjE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a2bcd1c25c1d29e22756ccae094032ab4ada2268",
+        "rev": "877bb495a6f8faf0d89fc10bd142c4b7ed2bcc0b",
         "type": "github"
       },
       "original": {
@@ -2176,11 +2176,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1762747449,
-        "narHash": "sha256-Z1TKiux8K09a93w4PFDFsj8HFugXNy3iCC3Z8MpR5Rk=",
+        "lastModified": 1763704521,
+        "narHash": "sha256-ceYEV6PnvUN8Zixao4gpPuN+VT3B0SlAXKuPNHZhqUY=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "6338574bc5c036487486acde264f38f39ea15fad",
+        "rev": "f379ff5722a821212eb59ada9cf8e51cb3654aad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/217037c2ae011d131a0a7ecefd23b6ad99ac4f1b?narHash=sha256-0pAfeIDseUKd22XVrH6V9qXD8kD1yxJHG%2BhiD4/xIVA%3D' (2025-11-15)
  → 'github:AvengeMedia/DankMaterialShell/58bf1899410536c4244b9d44c243426dc1b2a2c9?narHash=sha256-uYgLhTSxWs9IRpia5Hxd7AMCaE0plr0%2BQhWBf26h9V0%3D' (2025-11-22)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/6831e9334d8efd7b1f9b570be748e7cf0173f6b7?dir=pkgs/firefox-addons&narHash=sha256-bsHnmNm/2ev8XNzKibc6swU5zM2bB3/v3UbtlQyS1dA%3D' (2025-11-15)
  → 'gitlab:rycee/nur-expressions/a717a95e58c8dfdb3d07797b97fdedc97697d65c?dir=pkgs/firefox-addons&narHash=sha256-bg%2BMOwWA4GgsHQ2QZQHCixIs0ouPHvN1EVAzMTELPiQ%3D' (2025-11-22)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/c3bc79be5ee97455262c6c677bbf065eed07948c?narHash=sha256-oLugbe2pJv39BjWg7kAljn6vUxjVr/ArkITDX8fFd2Y%3D' (2025-11-15)
  → 'github:nix-community/home-manager/d10a9b16b2a3ee28433f3d1c603f4e9f1fecb8e1?narHash=sha256-AUc78Qv3sWir0hvbmfXoZ7Jzq9VVL97l%2BsP9Jgms%2BJU%3D' (2025-11-21)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/43527d363472b52f17dd9f9f4f87ec25cbf8a399?narHash=sha256-s5FF0rQE6UIBAUfqk5ZqGedU3bhW0OvXfmz5lzJGurY%3D' (2025-11-13)
  → 'github:hyprwm/Hyprland/abb2f7ee6fc99c31b6fac05568f29c92b59565df?narHash=sha256-Q5IO8VKW2fFHb6Ix6auy6SEMA6NS6pNeuefBai4%2BPHY%3D' (2025-11-21)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/4dafa28d4f79877d67a7d1a654cddccf8ebf15da?narHash=sha256-LZgMds7M94%2BvuMql2bERQ6LiFFdhgsEFezE4Vn%2BYs3A%3D' (2025-09-26)
  → 'github:hyprwm/hyprlang/deea98d5b61d066bdc7a68163edd2c4bd28d3a6b?narHash=sha256-JNgz3Fz2KMzkT7aR72wsgu/xNeJB//LSmdilh8Z/Zao%3D' (2025-11-16)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/926689ddb9c0a8787e58c02c765a62e32d63d1f7?narHash=sha256-gQ9zJ%2BpUI4o%2BGh4Z6jhJll7jjCSwi8ZqJIhCE2oqwhQ%3D' (2025-11-06)
  → 'github:hyprwm/hyprutils/0c6411851cc779d551edc89b83966696201611aa?narHash=sha256-%2BZ0OfCo1MS8/aIutSAW5aJR9zTae1wz9kcJYMgpwN6M%3D' (2025-11-16)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/8e7576e79b88c16d7ee3bbd112c8d90070832885?narHash=sha256-j%2BrNQ119ffYUkYt2YYS6rnd6Jh/crMZmbqpkGLXaEt0%3D' (2025-11-06)
  → 'github:cachix/git-hooks.nix/7275fa67fbbb75891c16d9dee7d88e58aea2d761?narHash=sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA%3D' (2025-11-16)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/befb2670803cf7c1b9f0323449c8d9ccdaa485e2?narHash=sha256-NBTbKW0MVIMFCjAqeoJWkg5iUucAZ9jS4Lbyax6rIBE%3D' (2025-11-12)
  → 'github:hyprwm/hyprland-plugins/57961d69ad9725986290c8c0f2b0d118b645daee?narHash=sha256-hvElpSNHbYSBsn/GoJV0RgAecpn3vcC5kJso34XqwJw%3D' (2025-11-21)
• Updated input 'niri':
    'github:sodiboo/niri-flake/add7bcf2925547e180cc2fe6d5f4b5e7c579d086?narHash=sha256-LVYJJObvkWwR8QB/Srr6Rks%2BFw2lYvnRNOH0etV9DM8%3D' (2025-11-14)
  → 'github:sodiboo/niri-flake/960b925b8860e2c7b0149a530041358aa3201fbf?narHash=sha256-iPSL5ONtFDbocfEGCgR8Ik72VRDiS4Nuu7i27kmJ0jQ%3D' (2025-11-22)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/a52df533c4694b5ed0a04140af60fd26146df911?narHash=sha256-nmu7S8J9IJKLQyIkSU8QWYHygrfw76NHGTkcr%2BbXMX0%3D' (2025-11-13)
  → 'github:YaLTeR/niri/cfc01b895c0c7cbb9692852488675cc46693bd2a?narHash=sha256-b6hgDHjrLgTp4Y8DD5woGChg0R%2ByH16m0ZWVi9BhjrA%3D' (2025-11-22)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/3acb677ea67d4c6218f33de0db0955f116b7588c?narHash=sha256-A5LS0AJZ1yDPTa2fHxufZN%2B%2Bn8MCmtgrJDtxFxrH4S8%3D' (2025-11-13)
  → 'github:NixOS/nixpkgs/c58bc7f5459328e4afac201c5c4feb7c818d604b?narHash=sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB%2B19M%3D' (2025-11-20)
• Updated input 'niri/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/6338574bc5c036487486acde264f38f39ea15fad?narHash=sha256-Z1TKiux8K09a93w4PFDFsj8HFugXNy3iCC3Z8MpR5Rk%3D' (2025-11-10)
  → 'github:Supreeeme/xwayland-satellite/f379ff5722a821212eb59ada9cf8e51cb3654aad?narHash=sha256-ceYEV6PnvUN8Zixao4gpPuN%2BVT3B0SlAXKuPNHZhqUY%3D' (2025-11-21)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/c03e4ab01b392652992985dfc3dea2f1d370f746?narHash=sha256-jWbp1mb%2BVb2Z0oMQci859yDHULbDO57ISxLXG98DZHE%3D' (2025-11-15)
  → 'github:fufexan/nix-gaming/c34f0eefe470a12e486ee56d65e5e21a55161028?narHash=sha256-FD8dx7R543AFOnYX2sRwTGA4mcC1gVQ92D1RHzz6Cs4%3D' (2025-11-22)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/26d05891e14c88eb4a5d5bee659c0db5afb609d8?narHash=sha256-xxdepIcb39UJ94%2BYydGP221rjnpkDZUlykKuF54PsqI%3D' (2025-11-06)
  → 'github:hercules-ci/flake-parts/52a2caecc898d0b46b2b905f058ccc5081f842da?narHash=sha256-8oNVE8TrD19ulHinjaqONf9QWCKK%2Bw4url56cdStMpM%3D' (2025-11-12)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/ffcdcf99d65c61956d882df249a9be53e5902ea5?narHash=sha256-lz718rr1BDpZBYk7%2BG8cE6wee3PiBUpn8aomG/vLLiY%3D' (2025-11-05)
  → 'github:NixOS/nixpkgs/85a6c4a07faa12aaccd81b36ba9bfc2bec974fa1?narHash=sha256-3YJkOBrFpmcusnh7i8GXXEyh7qZG/8F5z5%2B717550Hk%3D' (2025-11-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3acb677ea67d4c6218f33de0db0955f116b7588c?narHash=sha256-A5LS0AJZ1yDPTa2fHxufZN%2B%2Bn8MCmtgrJDtxFxrH4S8%3D' (2025-11-13)
  → 'github:NixOS/nixpkgs/c58bc7f5459328e4afac201c5c4feb7c818d604b?narHash=sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB%2B19M%3D' (2025-11-20)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/c5ae371f1a6a7fd27823bc500d9390b38c05fa55?narHash=sha256-4PqRErxfe%2B2toFJFgcRKZ0UI9NSIOJa%2B7RXVtBhy4KE%3D' (2025-11-12)
  → 'github:NixOS/nixpkgs/89c2b2330e733d6cdb5eae7b899326930c2c0648?narHash=sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw%3D' (2025-11-17)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=0a36e3ed40bf2de41b76ac363bc1f98820473786' (2025-11-15)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=ed036d514b0fdbce03158a0b331305be166f4555' (2025-11-20)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/a2bcd1c25c1d29e22756ccae094032ab4ada2268?narHash=sha256-A91a%2BK0Q9wfdPLwL06e/kbHeAWSzPYy2EGdTDsyfb%2Bs%3D' (2025-11-13)
  → 'github:Mic92/sops-nix/877bb495a6f8faf0d89fc10bd142c4b7ed2bcc0b?narHash=sha256-VefBA1JWRXM929mBAFohFUtQJLUnEwZ2vmYUNkFnSjE%3D' (2025-11-20)```