### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762356719,
-        "narHash": "sha256-qwd/xdoOya1m8FENle+4hWnydCtlXUWLAW/Auk6WL7s=",
+        "lastModified": 1763922789,
+        "narHash": "sha256-XnkWjCpeXfip9tqYdL0b0zzBDjq+dgdISvEdSVGdVyA=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "6d0b3567584691bf9d8fedb5d0093309e2f979c7",
+        "rev": "a20a0e67a33b6848378a91b871b89588d3a12573",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763732117,
-        "narHash": "sha256-/zBu6slgHtkuFZFJ4ReKS3NO6rdwEv4KcaYADkz6KyA=",
+        "lastModified": 1764351487,
+        "narHash": "sha256-7XJcTfz0dPhBd7nfyjcFxT1LIIctJZ2LthiI2Ltd7zY=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "a34640558e83eb3ba0d52c52cb5ffd0465786e4b",
+        "rev": "2031f4a0507d0f7ab3e1aaff4c027a010feee447",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763788986,
-        "narHash": "sha256-uYgLhTSxWs9IRpia5Hxd7AMCaE0plr0+QhWBf26h9V0=",
+        "lastModified": 1764390755,
+        "narHash": "sha256-PRd2eFVx5w++XPLn20zki/B92B6xUGogNGp8U9u2wBI=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "58bf1899410536c4244b9d44c243426dc1b2a2c9",
+        "rev": "9c887fbe63c8b34018df3641635c60bc3c53e01f",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
     "dms-official-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1762786607,
-        "narHash": "sha256-qGseA9QsSXEffTKOvLjJDgW0V5Ej39Mc+fcMP2dcNCM=",
+        "lastModified": 1764085668,
+        "narHash": "sha256-KtOu12NVLdyho9T4EXJaReNhFO98nAXpemkb6yeOvwE=",
         "owner": "AvengeMedia",
         "repo": "dms-plugins",
-        "rev": "2b2353cace2bb63c3559f32576c028d52498c86c",
+        "rev": "3bc66f186a8184cb8eca5fdfc0699cb4a828cd90",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1763784262,
-        "narHash": "sha256-bg+MOwWA4GgsHQ2QZQHCixIs0ouPHvN1EVAzMTELPiQ=",
+        "lastModified": 1764389080,
+        "narHash": "sha256-BEn1Z9Uv20u2DS6wzLKdzx5kAzynM3wMQ9JnGf3VJvI=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "a717a95e58c8dfdb3d07797b97fdedc97697d65c",
+        "rev": "897437c09bf22ce59efb3370f0783d0c662dba31",
         "type": "gitlab"
       },
       "original": {
@@ -303,11 +303,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -370,11 +370,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763416652,
-        "narHash": "sha256-8EBEEvtzQ11LCxpQHMNEBQAGtQiCu/pqP9zSovDSbNM=",
+        "lastModified": 1764194569,
+        "narHash": "sha256-iUM9ktarEzThkayyZrzQ7oycPshAY2XRQqVKz0xX/L0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ea164b7c9ccdc2321379c2ff78fd4317b4c41312",
+        "rev": "9651819d75f6c7ffaf8a9227490ac704f29659f0",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763748372,
-        "narHash": "sha256-AUc78Qv3sWir0hvbmfXoZ7Jzq9VVL97l+sP9Jgms+JU=",
+        "lastModified": 1764361670,
+        "narHash": "sha256-jgWzgpIaHbL3USIq0gihZeuy1lLf2YSfwvWEwnfAJUw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d10a9b16b2a3ee28433f3d1c603f4e9f1fecb8e1",
+        "rev": "780be8ef503a28939cf9dc7996b48ffb1a3e04c6",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758463745,
-        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
+        "lastModified": 1763992789,
+        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
+        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762462052,
-        "narHash": "sha256-6roLYzcDf4V38RUMSqycsOwAnqfodL6BmhRkUtwIgdA=",
+        "lastModified": 1763733840,
+        "narHash": "sha256-JnET78yl5RvpGuDQy3rCycOCkiKoLr5DN1fPhRNNMco=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "ffc999d980c7b3bca85d3ebd0a9fbadf984a8162",
+        "rev": "8f1bec691b2d198c60cccabca7a94add2df4ed1a",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1763750925,
-        "narHash": "sha256-Q5IO8VKW2fFHb6Ix6auy6SEMA6NS6pNeuefBai4+PHY=",
+        "lastModified": 1764283894,
+        "narHash": "sha256-5BWYZDmJKwUGxhY+43obUZItkAL6rm3xkvBYdltUWz4=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "abb2f7ee6fc99c31b6fac05568f29c92b59565df",
+        "rev": "7e1e24fea615503a3cc05218c12b06c1b6cabdc7",
         "type": "github"
       },
       "original": {
@@ -782,11 +782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762755186,
-        "narHash": "sha256-ZjjETUHtoEhVN7JI1Cbt3p/KcXpK8ZQaPHx7UkG1OgA=",
+        "lastModified": 1763727565,
+        "narHash": "sha256-vRff/2R1U1jzPBy4OODqh2kfUzmizW/nfV2ROzTDIKo=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "66356e20a8ed348aa49c1b9ceace786e224225b3",
+        "rev": "7724d3a12a0453e7aae05f2ef39474219f05a4b4",
         "type": "github"
       },
       "original": {
@@ -811,11 +811,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763732618,
-        "narHash": "sha256-hvElpSNHbYSBsn/GoJV0RgAecpn3vcC5kJso34XqwJw=",
+        "lastModified": 1764195033,
+        "narHash": "sha256-ALRU1VfTv+Vld0bEq3UHSiM6vYxALWvss7d2eOymqbM=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "57961d69ad9725986290c8c0f2b0d118b645daee",
+        "rev": "84659a2502df6b2fd245441c16a8365f5e1cd16d",
         "type": "github"
       },
       "original": {
@@ -865,11 +865,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763254292,
-        "narHash": "sha256-JNgz3Fz2KMzkT7aR72wsgu/xNeJB//LSmdilh8Z/Zao=",
+        "lastModified": 1763819661,
+        "narHash": "sha256-0jLarTR/BLWdGlboM86bPVP2zKJNI2jvo3JietnDkOM=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "deea98d5b61d066bdc7a68163edd2c4bd28d3a6b",
+        "rev": "a318deec0c12409ec39c68d2be8096b636dc2a5c",
         "type": "github"
       },
       "original": {
@@ -917,11 +917,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762463729,
-        "narHash": "sha256-2fYkU/mdz8WKY3dkDPlE/j6hTxIwqultsx4gMMsMns0=",
+        "lastModified": 1763503177,
+        "narHash": "sha256-VPoiswJBBmTLVuNncvT/8FpFR+sYcAi/LgP/zTZ+5rA=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "88483bdee5329ec985f0c8f834c519cd18cfe532",
+        "rev": "f4e1e12755567ecf39090203b8f43eace8279630",
         "type": "github"
       },
       "original": {
@@ -942,11 +942,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763323331,
-        "narHash": "sha256-+Z0OfCo1MS8/aIutSAW5aJR9zTae1wz9kcJYMgpwN6M=",
+        "lastModified": 1763996058,
+        "narHash": "sha256-DsqzFZvrEV+aDmavjaD4/bk5qxeZwhGxPWBQdpFyM9Y=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "0c6411851cc779d551edc89b83966696201611aa",
+        "rev": "0168583075baffa083032ed13a8bea8ea12f281a",
         "type": "github"
       },
       "original": {
@@ -967,11 +967,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755184602,
-        "narHash": "sha256-RCBQN8xuADB0LEgaKbfRqwm6CdyopE1xIEhNc67FAbw=",
+        "lastModified": 1763640274,
+        "narHash": "sha256-Uan1Nl9i4TF/kyFoHnTq1bd/rsWh4GAK/9/jDqLbY5A=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "b3b0f1f40ae09d4447c20608e5a4faf8bf3c492d",
+        "rev": "f6cf414ca0e16a4d30198fd670ec86df3c89f671",
         "type": "github"
       },
       "original": {
@@ -1040,11 +1040,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763453666,
-        "narHash": "sha256-Hu8lDUlbMFvcYX30LBXX7Gq5FbU35bERH0pSX5qHf/Q=",
+        "lastModified": 1764275117,
+        "narHash": "sha256-DRcv8Y0BnWm4ZhUQnaYk1dNzC6ZhA2W9Vv5Jl4n0RbE=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "b843b551415c7aecc97c8b3ab3fff26fd0cd8bbf",
+        "rev": "96023dcc9a0febaaa3b91f447b9ae2fbe86f2923",
         "type": "github"
       },
       "original": {
@@ -1199,11 +1199,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1763804463,
-        "narHash": "sha256-iPSL5ONtFDbocfEGCgR8Ik72VRDiS4Nuu7i27kmJ0jQ=",
+        "lastModified": 1764405884,
+        "narHash": "sha256-TnvBRPmcpcyinvLgsitHS7w5soSa6yNBfRYEI2TK1Ts=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "960b925b8860e2c7b0149a530041358aa3201fbf",
+        "rev": "10aae4855ee275f7d80d85f4328c24265fb20f1f",
         "type": "github"
       },
       "original": {
@@ -1232,11 +1232,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1763799335,
-        "narHash": "sha256-b6hgDHjrLgTp4Y8DD5woGChg0R+yH16m0ZWVi9BhjrA=",
+        "lastModified": 1764399944,
+        "narHash": "sha256-FC9eYtSmplgxllCX4/3hJq5J3sXWKLSc7at8ZUxycVw=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "cfc01b895c0c7cbb9692852488675cc46693bd2a",
+        "rev": "b35bcae35b3f9665043c335e55ed5828af77db85",
         "type": "github"
       },
       "original": {
@@ -1267,11 +1267,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1763776301,
-        "narHash": "sha256-FD8dx7R543AFOnYX2sRwTGA4mcC1gVQ92D1RHzz6Cs4=",
+        "lastModified": 1764294866,
+        "narHash": "sha256-Kn0+e5avInNAX7Rf3qKlUGunpcc8ryutoZLRXzQa6BY=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "c34f0eefe470a12e486ee56d65e5e21a55161028",
+        "rev": "f189ee5932ef2e0fcc4f63d12a698a968b8450e8",
         "type": "github"
       },
       "original": {
@@ -1346,11 +1346,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1764242076,
+        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
         "type": "github"
       },
       "original": {
@@ -1407,11 +1407,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1764316264,
+        "narHash": "sha256-82L+EJU+40+FIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "9a7b80b6f82a71ea04270d7ba11b48855681c4b0",
         "type": "github"
       },
       "original": {
@@ -1423,11 +1423,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1764242076,
+        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
         "type": "github"
       },
       "original": {
@@ -1471,11 +1471,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1763312402,
-        "narHash": "sha256-3YJkOBrFpmcusnh7i8GXXEyh7qZG/8F5z5+717550Hk=",
+        "lastModified": 1763618868,
+        "narHash": "sha256-v5afmLjn/uyD9EQuPBn7nZuaZVV9r+JerayK/4wvdWA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85a6c4a07faa12aaccd81b36ba9bfc2bec974fa1",
+        "rev": "a8d610af3f1a5fb71e23e08434d8d61a466fc942",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1487,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1764316264,
+        "narHash": "sha256-82L+EJU+40+FIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "9a7b80b6f82a71ea04270d7ba11b48855681c4b0",
         "type": "github"
       },
       "original": {
@@ -1593,11 +1593,11 @@
         "sonarlint-nvim": "sonarlint-nvim"
       },
       "locked": {
-        "lastModified": 1763005151,
-        "narHash": "sha256-avJPxRT/4criRvyi8tJ8aaqbPqCAJgXSO7E2Xhi5EWM=",
+        "lastModified": 1764445870,
+        "narHash": "sha256-H1EHsm1xf1d3MZJMfSzQvy+ifIzGLh+8LENv/QIf96c=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "4cb7f6054430e1eccca6d9a3b7ad3eef2dba684e",
+        "rev": "264864708335c04c27034df720df6a51a2726a30",
         "type": "github"
       },
       "original": {
@@ -1632,11 +1632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763319842,
-        "narHash": "sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA=",
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7275fa67fbbb75891c16d9dee7d88e58aea2d761",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
         "type": "github"
       },
       "original": {
@@ -1652,11 +1652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763629934,
-        "narHash": "sha256-jWz10RbNAyylJbH4cUTLS/CsDjkd8gxfT8OsIgQIgEg=",
+        "lastModified": 1764045583,
+        "narHash": "sha256-W24ReyRrhOKTKIsuAMkY5hnVlCufGoONM79sjUoyQkk=",
         "ref": "master",
-        "rev": "ed036d514b0fdbce03158a0b331305be166f4555",
-        "revCount": 708,
+        "rev": "e9bad67619ee9937a1bbecfc6ad3b4231d2ecdc3",
+        "revCount": 709,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1727,11 +1727,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763433504,
-        "narHash": "sha256-cVid5UNpk88sPYHkLAA5aZEHOFQXSB/2L1vl18Aq7IM=",
+        "lastModified": 1764211126,
+        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "42ce16c6d8318a654d53f047c9400b7d902d6e61",
+        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
         "type": "github"
       },
       "original": {
@@ -1822,15 +1822,15 @@
     "sonarlint-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1747678127,
-        "narHash": "sha256-ZfMUkIFu6nQN0XaOHIzQKJZRIaWzIaV8fsjYDbwGXBg=",
-        "owner": "Alfaixx",
+        "lastModified": 1759572577,
+        "narHash": "sha256-1eUwgHvegULo33xVjvV3b90fSlJ8Ax10iDCZE4IPo58=",
+        "owner": "schrieveslaach",
         "repo": "sonarlint.nvim",
-        "rev": "ff15e709b51d856f12c3684c150f130d4b1becd8",
+        "rev": "1d49a469265e271f02b6efcf09c215e4560bd5fa",
         "type": "gitlab"
       },
       "original": {
-        "owner": "Alfaixx",
+        "owner": "schrieveslaach",
         "repo": "sonarlint.nvim",
         "type": "gitlab"
       }
@@ -1842,11 +1842,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763607916,
-        "narHash": "sha256-VefBA1JWRXM929mBAFohFUtQJLUnEwZ2vmYUNkFnSjE=",
+        "lastModified": 1764021963,
+        "narHash": "sha256-1m84V2ROwNEbqeS9t37/mkry23GBhfMt8qb6aHHmjuc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "877bb495a6f8faf0d89fc10bd142c4b7ed2bcc0b",
+        "rev": "c482a1c1bbe030be6688ed7dc84f7213f304f1ec",
         "type": "github"
       },
       "original": {
@@ -2089,11 +2089,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1763704521,
-        "narHash": "sha256-ceYEV6PnvUN8Zixao4gpPuN+VT3B0SlAXKuPNHZhqUY=",
+        "lastModified": 1764366786,
+        "narHash": "sha256-yVCJ4Qe/JkdKDu0DddFdAQgDQVeF12nxH7zv3jtooV4=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "f379ff5722a821212eb59ada9cf8e51cb3654aad",
+        "rev": "b362a3873710a42f7ac2d8ba03772d8290733934",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'chaotic':
    'github:chaotic-cx/nyx/a34640558e83eb3ba0d52c52cb5ffd0465786e4b?narHash=sha256-/zBu6slgHtkuFZFJ4ReKS3NO6rdwEv4KcaYADkz6KyA%3D' (2025-11-21)
  → 'github:chaotic-cx/nyx/2031f4a0507d0f7ab3e1aaff4c027a010feee447?narHash=sha256-7XJcTfz0dPhBd7nfyjcFxT1LIIctJZ2LthiI2Ltd7zY%3D' (2025-11-28)
• Updated input 'chaotic/home-manager':
    'github:nix-community/home-manager/ea164b7c9ccdc2321379c2ff78fd4317b4c41312?narHash=sha256-8EBEEvtzQ11LCxpQHMNEBQAGtQiCu/pqP9zSovDSbNM%3D' (2025-11-17)
  → 'github:nix-community/home-manager/9651819d75f6c7ffaf8a9227490ac704f29659f0?narHash=sha256-iUM9ktarEzThkayyZrzQ7oycPshAY2XRQqVKz0xX/L0%3D' (2025-11-26)
• Updated input 'chaotic/jovian':
    'github:Jovian-Experiments/Jovian-NixOS/b843b551415c7aecc97c8b3ab3fff26fd0cd8bbf?narHash=sha256-Hu8lDUlbMFvcYX30LBXX7Gq5FbU35bERH0pSX5qHf/Q%3D' (2025-11-18)
  → 'github:Jovian-Experiments/Jovian-NixOS/96023dcc9a0febaaa3b91f447b9ae2fbe86f2923?narHash=sha256-DRcv8Y0BnWm4ZhUQnaYk1dNzC6ZhA2W9Vv5Jl4n0RbE%3D' (2025-11-27)
• Updated input 'chaotic/nixpkgs':
    'github:NixOS/nixpkgs/89c2b2330e733d6cdb5eae7b899326930c2c0648?narHash=sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw%3D' (2025-11-17)
  → 'github:NixOS/nixpkgs/2fad6eac6077f03fe109c4d4eb171cf96791faa4?narHash=sha256-sKoIWfnijJ0%2B9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI%3D' (2025-11-27)
• Updated input 'chaotic/rust-overlay':
    'github:oxalica/rust-overlay/42ce16c6d8318a654d53f047c9400b7d902d6e61?narHash=sha256-cVid5UNpk88sPYHkLAA5aZEHOFQXSB/2L1vl18Aq7IM%3D' (2025-11-18)
  → 'github:oxalica/rust-overlay/895935bff08cfcfb663fb9c8263c43596e7cd1ed?narHash=sha256-p5y13PnMZYd5WdHk%2BXCzyUaLGBUCwnz2n4KYKEZM0Pw%3D' (2025-11-27)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/58bf1899410536c4244b9d44c243426dc1b2a2c9?narHash=sha256-uYgLhTSxWs9IRpia5Hxd7AMCaE0plr0%2BQhWBf26h9V0%3D' (2025-11-22)
  → 'github:AvengeMedia/DankMaterialShell/9c887fbe63c8b34018df3641635c60bc3c53e01f?narHash=sha256-PRd2eFVx5w%2B%2BXPLn20zki/B92B6xUGogNGp8U9u2wBI%3D' (2025-11-29)
• Updated input 'dms-official-plugins':
    'github:AvengeMedia/dms-plugins/2b2353cace2bb63c3559f32576c028d52498c86c?narHash=sha256-qGseA9QsSXEffTKOvLjJDgW0V5Ej39Mc%2BfcMP2dcNCM%3D' (2025-11-10)
  → 'github:AvengeMedia/dms-plugins/3bc66f186a8184cb8eca5fdfc0699cb4a828cd90?narHash=sha256-KtOu12NVLdyho9T4EXJaReNhFO98nAXpemkb6yeOvwE%3D' (2025-11-25)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/a717a95e58c8dfdb3d07797b97fdedc97697d65c?dir=pkgs/firefox-addons&narHash=sha256-bg%2BMOwWA4GgsHQ2QZQHCixIs0ouPHvN1EVAzMTELPiQ%3D' (2025-11-22)
  → 'gitlab:rycee/nur-expressions/897437c09bf22ce59efb3370f0783d0c662dba31?dir=pkgs/firefox-addons&narHash=sha256-BEn1Z9Uv20u2DS6wzLKdzx5kAzynM3wMQ9JnGf3VJvI%3D' (2025-11-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3b955f5f0a942f9f60cdc9cacb7844335d0f21c3?narHash=sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA%3D' (2025-09-21)
  → 'github:nix-community/home-manager/44831a7eaba4360fb81f2acc5ea6de5fde90aaa3?narHash=sha256-WHkdBlw6oyxXIra/vQPYLtqY%2B3G8dUVZM8bEXk0t8x4%3D' (2025-11-24)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/d10a9b16b2a3ee28433f3d1c603f4e9f1fecb8e1?narHash=sha256-AUc78Qv3sWir0hvbmfXoZ7Jzq9VVL97l%2BsP9Jgms%2BJU%3D' (2025-11-21)
  → 'github:nix-community/home-manager/780be8ef503a28939cf9dc7996b48ffb1a3e04c6?narHash=sha256-jgWzgpIaHbL3USIq0gihZeuy1lLf2YSfwvWEwnfAJUw%3D' (2025-11-28)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/abb2f7ee6fc99c31b6fac05568f29c92b59565df?narHash=sha256-Q5IO8VKW2fFHb6Ix6auy6SEMA6NS6pNeuefBai4%2BPHY%3D' (2025-11-21)
  → 'github:hyprwm/Hyprland/7e1e24fea615503a3cc05218c12b06c1b6cabdc7?narHash=sha256-5BWYZDmJKwUGxhY%2B43obUZItkAL6rm3xkvBYdltUWz4%3D' (2025-11-27)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/6d0b3567584691bf9d8fedb5d0093309e2f979c7?narHash=sha256-qwd/xdoOya1m8FENle%2B4hWnydCtlXUWLAW/Auk6WL7s%3D' (2025-11-05)
  → 'github:hyprwm/aquamarine/a20a0e67a33b6848378a91b871b89588d3a12573?narHash=sha256-XnkWjCpeXfip9tqYdL0b0zzBDjq%2BdgdISvEdSVGdVyA%3D' (2025-11-23)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/ffc999d980c7b3bca85d3ebd0a9fbadf984a8162?narHash=sha256-6roLYzcDf4V38RUMSqycsOwAnqfodL6BmhRkUtwIgdA%3D' (2025-11-06)
  → 'github:hyprwm/hyprgraphics/8f1bec691b2d198c60cccabca7a94add2df4ed1a?narHash=sha256-JnET78yl5RvpGuDQy3rCycOCkiKoLr5DN1fPhRNNMco%3D' (2025-11-21)
• Updated input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/66356e20a8ed348aa49c1b9ceace786e224225b3?narHash=sha256-ZjjETUHtoEhVN7JI1Cbt3p/KcXpK8ZQaPHx7UkG1OgA%3D' (2025-11-10)
  → 'github:hyprwm/hyprland-guiutils/7724d3a12a0453e7aae05f2ef39474219f05a4b4?narHash=sha256-vRff/2R1U1jzPBy4OODqh2kfUzmizW/nfV2ROzTDIKo%3D' (2025-11-21)
• Updated input 'hyprland/hyprland-guiutils/hyprtoolkit':
    'github:hyprwm/hyprtoolkit/88483bdee5329ec985f0c8f834c519cd18cfe532?narHash=sha256-2fYkU/mdz8WKY3dkDPlE/j6hTxIwqultsx4gMMsMns0%3D' (2025-11-06)
  → 'github:hyprwm/hyprtoolkit/f4e1e12755567ecf39090203b8f43eace8279630?narHash=sha256-VPoiswJBBmTLVuNncvT/8FpFR%2BsYcAi/LgP/zTZ%2B5rA%3D' (2025-11-18)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/deea98d5b61d066bdc7a68163edd2c4bd28d3a6b?narHash=sha256-JNgz3Fz2KMzkT7aR72wsgu/xNeJB//LSmdilh8Z/Zao%3D' (2025-11-16)
  → 'github:hyprwm/hyprlang/a318deec0c12409ec39c68d2be8096b636dc2a5c?narHash=sha256-0jLarTR/BLWdGlboM86bPVP2zKJNI2jvo3JietnDkOM%3D' (2025-11-22)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/0c6411851cc779d551edc89b83966696201611aa?narHash=sha256-%2BZ0OfCo1MS8/aIutSAW5aJR9zTae1wz9kcJYMgpwN6M%3D' (2025-11-16)
  → 'github:hyprwm/hyprutils/0168583075baffa083032ed13a8bea8ea12f281a?narHash=sha256-DsqzFZvrEV%2BaDmavjaD4/bk5qxeZwhGxPWBQdpFyM9Y%3D' (2025-11-24)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/b3b0f1f40ae09d4447c20608e5a4faf8bf3c492d?narHash=sha256-RCBQN8xuADB0LEgaKbfRqwm6CdyopE1xIEhNc67FAbw%3D' (2025-08-14)
  → 'github:hyprwm/hyprwayland-scanner/f6cf414ca0e16a4d30198fd670ec86df3c89f671?narHash=sha256-Uan1Nl9i4TF/kyFoHnTq1bd/rsWh4GAK/9/jDqLbY5A%3D' (2025-11-20)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/7275fa67fbbb75891c16d9dee7d88e58aea2d761?narHash=sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA%3D' (2025-11-16)
  → 'github:cachix/git-hooks.nix/50b9238891e388c9fdc6a5c49e49c42533a1b5ce?narHash=sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh%2BM4Qc%3D' (2025-11-24)
• Updated input 'hyprland/pre-commit-hooks/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
  → 'github:edolstra/flake-compat/f387cd2afec9419c8ee37694406ca490c3f34ee5?narHash=sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4%3D' (2025-10-27)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/57961d69ad9725986290c8c0f2b0d118b645daee?narHash=sha256-hvElpSNHbYSBsn/GoJV0RgAecpn3vcC5kJso34XqwJw%3D' (2025-11-21)
  → 'github:hyprwm/hyprland-plugins/84659a2502df6b2fd245441c16a8365f5e1cd16d?narHash=sha256-ALRU1VfTv%2BVld0bEq3UHSiM6vYxALWvss7d2eOymqbM%3D' (2025-11-26)
• Updated input 'niri':
    'github:sodiboo/niri-flake/960b925b8860e2c7b0149a530041358aa3201fbf?narHash=sha256-iPSL5ONtFDbocfEGCgR8Ik72VRDiS4Nuu7i27kmJ0jQ%3D' (2025-11-22)
  → 'github:sodiboo/niri-flake/10aae4855ee275f7d80d85f4328c24265fb20f1f?narHash=sha256-TnvBRPmcpcyinvLgsitHS7w5soSa6yNBfRYEI2TK1Ts%3D' (2025-11-29)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/cfc01b895c0c7cbb9692852488675cc46693bd2a?narHash=sha256-b6hgDHjrLgTp4Y8DD5woGChg0R%2ByH16m0ZWVi9BhjrA%3D' (2025-11-22)
  → 'github:YaLTeR/niri/b35bcae35b3f9665043c335e55ed5828af77db85?narHash=sha256-FC9eYtSmplgxllCX4/3hJq5J3sXWKLSc7at8ZUxycVw%3D' (2025-11-29)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/c58bc7f5459328e4afac201c5c4feb7c818d604b?narHash=sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB%2B19M%3D' (2025-11-20)
  → 'github:NixOS/nixpkgs/9a7b80b6f82a71ea04270d7ba11b48855681c4b0?narHash=sha256-82L%2BEJU%2B40%2BFIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o%3D' (2025-11-28)
• Updated input 'niri/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/f379ff5722a821212eb59ada9cf8e51cb3654aad?narHash=sha256-ceYEV6PnvUN8Zixao4gpPuN%2BVT3B0SlAXKuPNHZhqUY%3D' (2025-11-21)
  → 'github:Supreeeme/xwayland-satellite/b362a3873710a42f7ac2d8ba03772d8290733934?narHash=sha256-yVCJ4Qe/JkdKDu0DddFdAQgDQVeF12nxH7zv3jtooV4%3D' (2025-11-28)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/c34f0eefe470a12e486ee56d65e5e21a55161028?narHash=sha256-FD8dx7R543AFOnYX2sRwTGA4mcC1gVQ92D1RHzz6Cs4%3D' (2025-11-22)
  → 'github:fufexan/nix-gaming/f189ee5932ef2e0fcc4f63d12a698a968b8450e8?narHash=sha256-Kn0%2Be5avInNAX7Rf3qKlUGunpcc8ryutoZLRXzQa6BY%3D' (2025-11-28)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/52a2caecc898d0b46b2b905f058ccc5081f842da?narHash=sha256-8oNVE8TrD19ulHinjaqONf9QWCKK%2Bw4url56cdStMpM%3D' (2025-11-12)
  → 'github:hercules-ci/flake-parts/2cccadc7357c0ba201788ae99c4dfa90728ef5e0?narHash=sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q%3D' (2025-11-21)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/85a6c4a07faa12aaccd81b36ba9bfc2bec974fa1?narHash=sha256-3YJkOBrFpmcusnh7i8GXXEyh7qZG/8F5z5%2B717550Hk%3D' (2025-11-16)
  → 'github:NixOS/nixpkgs/a8d610af3f1a5fb71e23e08434d8d61a466fc942?narHash=sha256-v5afmLjn/uyD9EQuPBn7nZuaZVV9r%2BJerayK/4wvdWA%3D' (2025-11-20)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c58bc7f5459328e4afac201c5c4feb7c818d604b?narHash=sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB%2B19M%3D' (2025-11-20)
  → 'github:NixOS/nixpkgs/9a7b80b6f82a71ea04270d7ba11b48855681c4b0?narHash=sha256-82L%2BEJU%2B40%2BFIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o%3D' (2025-11-28)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/89c2b2330e733d6cdb5eae7b899326930c2c0648?narHash=sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw%3D' (2025-11-17)
  → 'github:NixOS/nixpkgs/2fad6eac6077f03fe109c4d4eb171cf96791faa4?narHash=sha256-sKoIWfnijJ0%2B9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI%3D' (2025-11-27)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/4cb7f6054430e1eccca6d9a3b7ad3eef2dba684e?narHash=sha256-avJPxRT/4criRvyi8tJ8aaqbPqCAJgXSO7E2Xhi5EWM%3D' (2025-11-13)
  → 'github:derethil/nvim-config/264864708335c04c27034df720df6a51a2726a30?narHash=sha256-H1EHsm1xf1d3MZJMfSzQvy%2BifIzGLh%2B8LENv/QIf96c%3D' (2025-11-29)
• Updated input 'nvim-config/sonarlint-nvim':
    'gitlab:Alfaixx/sonarlint.nvim/ff15e709b51d856f12c3684c150f130d4b1becd8?narHash=sha256-ZfMUkIFu6nQN0XaOHIzQKJZRIaWzIaV8fsjYDbwGXBg%3D' (2025-05-19)
  → 'gitlab:schrieveslaach/sonarlint.nvim/1d49a469265e271f02b6efcf09c215e4560bd5fa?narHash=sha256-1eUwgHvegULo33xVjvV3b90fSlJ8Ax10iDCZE4IPo58%3D' (2025-10-04)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=ed036d514b0fdbce03158a0b331305be166f4555' (2025-11-20)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=e9bad67619ee9937a1bbecfc6ad3b4231d2ecdc3' (2025-11-25)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/877bb495a6f8faf0d89fc10bd142c4b7ed2bcc0b?narHash=sha256-VefBA1JWRXM929mBAFohFUtQJLUnEwZ2vmYUNkFnSjE%3D' (2025-11-20)
  → 'github:Mic92/sops-nix/c482a1c1bbe030be6688ed7dc84f7213f304f1ec?narHash=sha256-1m84V2ROwNEbqeS9t37/mkry23GBhfMt8qb6aHHmjuc%3D' (2025-11-24)```