### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775558810,
-        "narHash": "sha256-fy95EdPnqQlpbP8+rk0yWKclWShCUS5VKs6P7/1MF2c=",
+        "lastModified": 1776702787,
+        "narHash": "sha256-qc5uwEWbuubzYthmZcfCapooZGXhoYZWfTQ24TozbCQ=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "7371b669b22aa2af980f913fc312a786d2f1abb2",
+        "rev": "9a1ca6b8cb4d86a599787a55b78f2ddf809bf945",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776224607,
-        "narHash": "sha256-2YXukXWFuRqr6IRq63hsDrTW1bHuKxGrwITuNsp9C24=",
+        "lastModified": 1776796985,
+        "narHash": "sha256-cNFg3H09sBZl1v9ds6PDHfLCUTDJbefGMSv+WxFs+9c=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "8c4679dc2ae89de25fd328ecbf761155e7a902b7",
+        "rev": "ac5956bbceb022998fc1dd0001322f10ef1e6dda",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1776181525,
-        "narHash": "sha256-g07GhYlAOH0agNE8dIOT33vZ0eviF/HY5xgAQRwLytk=",
+        "lastModified": 1776792814,
+        "narHash": "sha256-39dlIhz9KxUNQFxGpE9SvCviaOWAivdW0XJM8RnPNmg=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "fcd21edaf0ff9b69f9d32ea8590002d6acd1c503",
+        "rev": "d7d558d0b2e239e27b40bcf1af6fe12e323aa391",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776183001,
-        "narHash": "sha256-lvLKB5dTqjO1S/YonS9ZyWemEjO6QXtN4D76rYEYy4s=",
+        "lastModified": 1776608760,
+        "narHash": "sha256-ehDv8bF7k/2Kf4b8CCoSm51U/MOoFuLsRXqe5wZ57sE=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "4224303b6d7a50dd1cc3ffa78864050cc9536eec",
+        "rev": "7e06e29005853bbaaa3b1c1067f915d6e0db728a",
         "type": "github"
       },
       "original": {
@@ -200,17 +200,18 @@
     },
     "dank-material-shell": {
       "inputs": {
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
         ],
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1775750923,
-        "narHash": "sha256-BkJZN2O74p+5AujAEhmJBU7kSPLu+DVBPOoI63Hmy8w=",
+        "lastModified": 1776799121,
+        "narHash": "sha256-G+qUbf2jZ14mbfJdtQVvW2XPWelmOR4BaG9m4SUWIck=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "f2df53afcd0870445e7f3cd45e91ac135a04442e",
+        "rev": "c6ed64b24e414cd4b9588b645a6345b15fa697f4",
         "type": "github"
       },
       "original": {
@@ -247,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773889306,
-        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
         "type": "github"
       },
       "original": {
@@ -267,11 +268,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775870605,
-        "narHash": "sha256-t6D7Embz0dwSh6RArB0PPGYSFY/956g2tww6T0bCtxc=",
+        "lastModified": 1776821429,
+        "narHash": "sha256-A9BhLm0dyfAlCM7b1NMDx/fLN/m8V//ihrnMMkLiCR4=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "b6496f41b9b1a3e67d239026bae17026f2064e06",
+        "rev": "956cea9b7bb01346ebeebbac512aa71b90fd1365",
         "type": "github"
       },
       "original": {
@@ -315,6 +316,22 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
         "lastModified": 1730663653,
         "narHash": "sha256-kFCUWettiFHDIqxCWWQ9qY8pVh+Lj+XL0Giyy/kdomg=",
         "owner": "hraban",
@@ -329,7 +346,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_5": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -345,7 +362,7 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1751685974,
@@ -361,7 +378,7 @@
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
       }
     },
-    "flake-compat_6": {
+    "flake-compat_7": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -666,7 +683,7 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_5",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nix-gaming",
@@ -674,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -800,11 +817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775900011,
-        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
+        "lastModified": 1776777932,
+        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
+        "rev": "5d5640599a0050b994330328b9fd45709c909720",
         "type": "github"
       },
       "original": {
@@ -874,11 +891,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772461003,
-        "narHash": "sha256-pVICsV7FtcEeVwg5y/LFh3XFUkVJninm/P1j/JHzEbM=",
+        "lastModified": 1776511930,
+        "narHash": "sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "b62396457b9cfe2ebf24fe05404b09d2a40f8ed7",
+        "rev": "39435900785d0c560c6ae8777d29f28617d031ef",
         "type": "github"
       },
       "original": {
@@ -903,11 +920,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775496928,
-        "narHash": "sha256-Ds759WU03mGWtu3I43J+5GF5Ni8TvF+GYQUFD+fVeMo=",
+        "lastModified": 1776426399,
+        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "cf95d93d17baa18f1d9b016b3afe27f820521a6e",
+        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
         "type": "github"
       },
       "original": {
@@ -935,11 +952,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1775828308,
-        "narHash": "sha256-XsijqtwDQd8pf/PweiGGuX7O1250f3YOchQ+oGm0eCc=",
+        "lastModified": 1776805766,
+        "narHash": "sha256-IVUzmEflwGk02ZAuBBc3h0gWu/p2c9H+cg//dgWlFBg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "f7755322fc515108cc9eed8113c09492d4a352c1",
+        "rev": "019dac7a0560145d7a557005a21a7fe48ecabe3e",
         "type": "github"
       },
       "original": {
@@ -981,11 +998,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774710575,
-        "narHash": "sha256-p7Rcw13+gA4Z9EI3oGYe3neQ3FqyOOfZCleBTfhJ95Q=",
+        "lastModified": 1776426575,
+        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "0703df899520001209646246bef63358c9881e36",
+        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
         "type": "github"
       },
       "original": {
@@ -1010,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771865848,
-        "narHash": "sha256-xwNa+1D8WPsDnJtUofDrtyDCZKZotbUymzV/R5s+M0I=",
+        "lastModified": 1776702833,
+        "narHash": "sha256-xmzpa+kFv1zDei3nT1sWZ/Q9TdMK/Rhx1I09VuO2F3E=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "b85a56b9531013c79f2f3846fd6ee2ff014b8960",
+        "rev": "6acc0738f298f5efe40a99db2c12449112d65633",
         "type": "github"
       },
       "original": {
@@ -1064,11 +1081,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459629,
-        "narHash": "sha256-/iwvNUYShmmnwmz/czEUh6+0eF5vCMv0xtDW0STPIuM=",
+        "lastModified": 1776426736,
+        "narHash": "sha256-rl7i4aY+9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "7615ee388de18239a4ab1400946f3d0e498a8186",
+        "rev": "7833ff33b2e82d3406337b5dcf0d1cec595d83e9",
         "type": "github"
       },
       "original": {
@@ -1141,11 +1158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774911391,
-        "narHash": "sha256-c4YVwO33Mmw+FIV8E0u3atJZagHvGTJ9Jai6RtiB8rE=",
+        "lastModified": 1776428866,
+        "narHash": "sha256-XfRlBolGtjvalTHJp3XvvpYLBjkMhaZLLU0WqZ91Fcg=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e6caa3d4d1427eedbdf556cf4ceb70f2d9c0b56d",
+        "rev": "eedd60805cd96d4442586f2ba5fe51d549b12674",
         "type": "github"
       },
       "original": {
@@ -1166,11 +1183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772459835,
-        "narHash": "sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy+8X2lFZsak=",
+        "lastModified": 1776430932,
+        "narHash": "sha256-Yv3RPiUvl7CAsJgwIVsqcj7akn1gLyJP1F/mocof5hA=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "0a692d4a645165eebd65f109146b8861e3a925e7",
+        "rev": "4c2fcc06dc9722c97dbb54ba649c69b18ce83d2e",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775414057,
-        "narHash": "sha256-mDpHnf+MkdOxEqIM1TnckYYh9p1SXR8B3KQfNZ12M8s=",
+        "lastModified": 1776728575,
+        "narHash": "sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "86012ee01b0fdd8bf3101ef38816f2efbee42490",
+        "rev": "f3a80888783702a39691b684d099e16b83ed4702",
         "type": "github"
       },
       "original": {
@@ -1337,7 +1354,7 @@
     "mac-app-util": {
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_5",
         "systems": "systems_6",
@@ -1465,11 +1482,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1775877135,
-        "narHash": "sha256-nAqtUMy22olwyiOJB0CASVrbu5XB5+43GjlbIJ1KuvQ=",
+        "lastModified": 1776805172,
+        "narHash": "sha256-5xA2D+iOEMoKBcTSbQe8Ztao5APX7C3eVeiFAdCg3WM=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "f943da038fd668d435c2d17916577f295faa8839",
+        "rev": "035f8ef8a0a5ec8f226231b15e84ebd88a81b1f3",
         "type": "github"
       },
       "original": {
@@ -1486,11 +1503,11 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1775761264,
-        "narHash": "sha256-3L5DstpSGu2WJAJ2qBUBKXnafD/3quSTz0BFMxeysV4=",
+        "lastModified": 1776366944,
+        "narHash": "sha256-zvRM1Egnw/s27u5UeKrQy+OnRtSUHH8/zguFpn/QvnU=",
         "owner": "derethil",
         "repo": "niri-smart-workspace",
-        "rev": "60b4e9785dc5b89b474e638d98f794d1f1484693",
+        "rev": "7b10eb74358bea855a1a2db48c9074b94a493e7d",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1536,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1775561155,
-        "narHash": "sha256-TK2IrqQivRcwqJa0suZMbcsN17CtA8Uu0v7CDnLATb0=",
+        "lastModified": 1776800113,
+        "narHash": "sha256-8UFcj0LV4zZ0gTX96LlbzpmBfYkoXsfb3ETg7GeRup8=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "599db847f857b8a7ff78ce02f15acab5d5d9fee1",
+        "rev": "e472b5b0f13d91fdf0e5d07551f68177d25043d0",
         "type": "github"
       },
       "original": {
@@ -1555,11 +1572,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1775875492,
-        "narHash": "sha256-xZXo5nKPMp7GLti08n+jSp8cHcZIV+N9mL1x9lzOkX0=",
+        "lastModified": 1776741712,
+        "narHash": "sha256-JvWRhIL+AL7CJCSgCwPFXMKzYRacIhHlb9nguFm/e3U=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "5a0a7103219f62e46433e193fc2fc7a00568747d",
+        "rev": "9fbfaf7ee04939f7f2fffc03094253c270b585b5",
         "type": "github"
       },
       "original": {
@@ -1575,11 +1592,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775365369,
-        "narHash": "sha256-DgH5mveLoau20CuTnaU5RXZWgFQWn56onQ4Du2CqYoI=",
+        "lastModified": 1776829403,
+        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "cef5cf82671e749ac87d69aadecbb75967e6f6c3",
+        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775103722,
-        "narHash": "sha256-j/oR6R0iKTT06zZhM16QprL/ylM1HHtOivrGaKbMU+E=",
+        "lastModified": 1776305949,
+        "narHash": "sha256-5Pqwqf4lEsZLZUcpefwMeq69d8hdirE83C5oWshBXo8=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "4f8cbe437ba7e047ed4582b35b8140124b9562b5",
+        "rev": "b2bb4ab9d8e2457eeec3caa279b394525fbbe1a7",
         "type": "github"
       },
       "original": {
@@ -1633,11 +1650,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776750258,
+        "narHash": "sha256-jab3OFEK7MpiAolaLBjvIxdf258UWvvusWxPJPE5ito=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "8d73c2809cb39eecce6284c38100e69a6064e5d9",
         "type": "github"
       },
       "original": {
@@ -1709,11 +1726,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1775811116,
-        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+        "lastModified": 1776560675,
+        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
         "type": "github"
       },
       "original": {
@@ -1741,11 +1758,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -1869,11 +1886,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1775126147,
-        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -1885,11 +1902,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1775811116,
-        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+        "lastModified": 1776560675,
+        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
         "type": "github"
       },
       "original": {
@@ -1923,11 +1940,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775907574,
-        "narHash": "sha256-7NF50ekvHT+K4nw56xYr2CzA+FX3TAAy4n5YODtPJNU=",
+        "lastModified": 1776829882,
+        "narHash": "sha256-G3keSZS+I6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14bcd8d7960bb40d1e1a0cb7dc69511267129776",
+        "rev": "daed3a795bd1df6f8c0e060ab3fdf2a8820d0653",
         "type": "github"
       },
       "original": {
@@ -1938,7 +1955,7 @@
     },
     "nvf": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_6",
         "flake-parts": "flake-parts_8",
         "mnw": "mnw",
         "ndg": "ndg",
@@ -2011,7 +2028,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore",
         "nixpkgs": [
           "hyprland",
@@ -2019,11 +2036,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -2061,11 +2078,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775720097,
-        "narHash": "sha256-p+vqkCuFfVNyQBo370wr6MebNUvz55RZiC0m8YKUhvQ=",
+        "lastModified": 1776761300,
+        "narHash": "sha256-0CTVYyznIl8QC6PpMoOSM2Qo4sIdHp3j3wV8lU7wON8=",
         "ref": "master",
-        "rev": "d4c92973b53d9fa34cc110d3b974eb6bde5b3027",
-        "revCount": 800,
+        "rev": "d60498adc038526b3d155e8ad61e51e78e6e32eb",
+        "revCount": 804,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -2175,7 +2192,7 @@
     },
     "snowfall-lib": {
       "inputs": {
-        "flake-compat": "flake-compat_6",
+        "flake-compat": "flake-compat_7",
         "flake-utils-plus": "flake-utils-plus",
         "nixpkgs": [
           "nixpkgs"
@@ -2202,11 +2219,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775682595,
-        "narHash": "sha256-0E9PohY/VuESLq0LR4doaH7hTag513sDDW5n5qmHd1Q=",
+        "lastModified": 1776771786,
+        "narHash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d2e8438d5886e92bc5e7c40c035ab6cae0c41f76",
+        "rev": "bef289e2248991f7afeb95965c82fbcd8ff72598",
         "type": "github"
       },
       "original": {
@@ -2544,11 +2561,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773601989,
-        "narHash": "sha256-2tJf/CQoHApoIudxHeJye+0Ii7scR0Yyi7pNiWk0Hn8=",
+        "lastModified": 1776608502,
+        "narHash": "sha256-UH8YoQxx4hFOm6qjMdjRQNRvSejFIR/wBZ8fW1p9sME=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "a9b862d1aa000a676d310cc62d249f7ad726233d",
+        "rev": "4a293523d36dfa367e67ec304cc718ea66a8fec2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:
• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/a26503528b4a4ab7310c6167da549f8fbee91f30?narHash=sha256-Ws02sv0IPKgo0JGaaiAFGt2IWnLQI%2Bi3Y8jeVBx6V80%3D' (2026-04-17)
  → 'github:xddxdd/nix-cachyos-kernel/ac5956bbceb022998fc1dd0001322f10ef1e6dda?narHash=sha256-cNFg3H09sBZl1v9ds6PDHfLCUTDJbefGMSv%2BWxFs%2B9c%3D' (2026-04-21)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/4224303b6d7a50dd1cc3ffa78864050cc9536eec?narHash=sha256-lvLKB5dTqjO1S/YonS9ZyWemEjO6QXtN4D76rYEYy4s%3D' (2026-04-14)
  → 'github:CachyOS/linux-cachyos/7e06e29005853bbaaa3b1c1067f915d6e0db728a?narHash=sha256-ehDv8bF7k/2Kf4b8CCoSm51U/MOoFuLsRXqe5wZ57sE%3D' (2026-04-19)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/b5e029226df5cc30c103651072d49a7af2878202?narHash=sha256-b9Hc0sTxjEzDbphzS9yQqxVha/7bsPIs2cQQQvaG45E%3D' (2026-04-16)
  → 'github:CachyOS/kernel-patches/d7d558d0b2e239e27b40bcf1af6fe12e323aa391?narHash=sha256-39dlIhz9KxUNQFxGpE9SvCviaOWAivdW0XJM8RnPNmg%3D' (2026-04-21)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/cc1e0e027707ad53dddae39d3b3e992262c7d8c7?narHash=sha256-9U8bL9X/0R9cZD3Uc/mN37AWvv5dB4WQqqjLRAxQfas%3D' (2026-04-16)
  → 'github:NixOS/nixpkgs/8d73c2809cb39eecce6284c38100e69a6064e5d9?narHash=sha256-jab3OFEK7MpiAolaLBjvIxdf258UWvvusWxPJPE5ito%3D' (2026-04-21)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/4c2c1937662b3973071ce3d3cac34436ee822e32?narHash=sha256-4019TOLn63jzPZdWT5SoKQZezxZxXzHKcFamK3Oh1Io%3D' (2026-04-18)
  → 'github:AvengeMedia/DankMaterialShell/c6ed64b24e414cd4b9588b645a6345b15fa697f4?narHash=sha256-G%2BqUbf2jZ14mbfJdtQVvW2XPWelmOR4BaG9m4SUWIck%3D' (2026-04-21)
• Updated input 'disko':
    'github:nix-community/disko/5ad85c82cc52264f4beddc934ba57f3789f28347?narHash=sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw%3D' (2026-03-19)
  → 'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/1728c7227d9b157e5d41501319def3c43959646d?narHash=sha256-dVhxEzfB0McRmlZkJaDJVKEW5R5In2Vd295x7ZG5xO4%3D' (2026-04-18)
  → 'github:AvengeMedia/dms-plugin-registry/956cea9b7bb01346ebeebbac512aa71b90fd1365?narHash=sha256-A9BhLm0dyfAlCM7b1NMDx/fLN/m8V//ihrnMMkLiCR4%3D' (2026-04-22)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681?narHash=sha256-7zSUFWsU0%2BjlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk%3D' (2026-04-17)
  → 'github:nix-community/home-manager/5d5640599a0050b994330328b9fd45709c909720?narHash=sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8%3D' (2026-04-21)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/889ee4f26d77ff0c36f5c4767ef0629371fd2c18?narHash=sha256-sGZir5sjqKOUv2fywOFXVolUnVJRtI1KvAqt42ql/mI%3D' (2026-04-18)
  → 'github:hyprwm/Hyprland/019dac7a0560145d7a557005a21a7fe48ecabe3e?narHash=sha256-IVUzmEflwGk02ZAuBBc3h0gWu/p2c9H%2Bcg//dgWlFBg%3D' (2026-04-21)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/7371b669b22aa2af980f913fc312a786d2f1abb2?narHash=sha256-fy95EdPnqQlpbP8%2Brk0yWKclWShCUS5VKs6P7/1MF2c%3D' (2026-04-07)
  → 'github:hyprwm/aquamarine/9a1ca6b8cb4d86a599787a55b78f2ddf809bf945?narHash=sha256-qc5uwEWbuubzYthmZcfCapooZGXhoYZWfTQ24TozbCQ%3D' (2026-04-20)
• Updated input 'hyprland/hyprcursor':
    'github:hyprwm/hyprcursor/b62396457b9cfe2ebf24fe05404b09d2a40f8ed7?narHash=sha256-pVICsV7FtcEeVwg5y/LFh3XFUkVJninm/P1j/JHzEbM%3D' (2026-03-02)
  → 'github:hyprwm/hyprcursor/39435900785d0c560c6ae8777d29f28617d031ef?narHash=sha256-fCpwFiTW0rT7oKJqr3cqHMnkwypSwQKpbtUEtxdkgrM%3D' (2026-04-18)
• Updated input 'hyprland/hyprgraphics':
    'github:hyprwm/hyprgraphics/cf95d93d17baa18f1d9b016b3afe27f820521a6e?narHash=sha256-Ds759WU03mGWtu3I43J%2B5GF5Ni8TvF%2BGYQUFD%2BfVeMo%3D' (2026-04-06)
  → 'github:hyprwm/hyprgraphics/68d064434787cf1ed4a2fe257c03c5f52f33cf84?narHash=sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM%3D' (2026-04-17)
• Updated input 'hyprland/hyprland-guiutils':
    'github:hyprwm/hyprland-guiutils/0703df899520001209646246bef63358c9881e36?narHash=sha256-p7Rcw13%2BgA4Z9EI3oGYe3neQ3FqyOOfZCleBTfhJ95Q%3D' (2026-03-28)
  → 'github:hyprwm/hyprland-guiutils/a968d211048e3ed538e47b84cb3649299578f19d?narHash=sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0%3D' (2026-04-17)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/7615ee388de18239a4ab1400946f3d0e498a8186?narHash=sha256-/iwvNUYShmmnwmz/czEUh6%2B0eF5vCMv0xtDW0STPIuM%3D' (2026-03-02)
  → 'github:hyprwm/hyprlang/7833ff33b2e82d3406337b5dcf0d1cec595d83e9?narHash=sha256-rl7i4aY%2B9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0%3D' (2026-04-17)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/e6caa3d4d1427eedbdf556cf4ceb70f2d9c0b56d?narHash=sha256-c4YVwO33Mmw%2BFIV8E0u3atJZagHvGTJ9Jai6RtiB8rE%3D' (2026-03-30)
  → 'github:hyprwm/hyprutils/eedd60805cd96d4442586f2ba5fe51d549b12674?narHash=sha256-XfRlBolGtjvalTHJp3XvvpYLBjkMhaZLLU0WqZ91Fcg%3D' (2026-04-17)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/0a692d4a645165eebd65f109146b8861e3a925e7?narHash=sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy%2B8X2lFZsak%3D' (2026-03-02)
  → 'github:hyprwm/hyprwayland-scanner/4c2fcc06dc9722c97dbb54ba649c69b18ce83d2e?narHash=sha256-Yv3RPiUvl7CAsJgwIVsqcj7akn1gLyJP1F/mocof5hA%3D' (2026-04-17)
• Updated input 'hyprland/hyprwire':
    'github:hyprwm/hyprwire/86012ee01b0fdd8bf3101ef38816f2efbee42490?narHash=sha256-mDpHnf%2BMkdOxEqIM1TnckYYh9p1SXR8B3KQfNZ12M8s%3D' (2026-04-05)
  → 'github:hyprwm/hyprwire/f3a80888783702a39691b684d099e16b83ed4702?narHash=sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU%3D' (2026-04-20)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/4e0eb042b67d863b1b34b3f64d52ceb9cd926735?narHash=sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU%3D' (2026-04-01)
  → 'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/a9b862d1aa000a676d310cc62d249f7ad726233d?narHash=sha256-2tJf/CQoHApoIudxHeJye%2B0Ii7scR0Yyi7pNiWk0Hn8%3D' (2026-03-15)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/4a293523d36dfa367e67ec304cc718ea66a8fec2?narHash=sha256-UH8YoQxx4hFOm6qjMdjRQNRvSejFIR/wBZ8fW1p9sME%3D' (2026-04-19)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/6059aca0cc623d8d896b02842606036c0954ba88?narHash=sha256-NX0dSUS86OBXfhD77rsajp3nJKg43HYhVdvlo9FkCsg%3D' (2026-04-17)
  → 'github:hyprwm/hyprland-plugins/6acc0738f298f5efe40a99db2c12449112d65633?narHash=sha256-xmzpa%2BkFv1zDei3nT1sWZ/Q9TdMK/Rhx1I09VuO2F3E%3D' (2026-04-20)
• Updated input 'niri':
    'github:sodiboo/niri-flake/f8cc32a3aba29fdacd06d80b0986028cfd413a22?narHash=sha256-oHVMjAMBukYnGeEE0EtCQsx8cNRv8WadHD8ZV3oZFSM%3D' (2026-04-18)
  → 'github:sodiboo/niri-flake/035f8ef8a0a5ec8f226231b15e84ebd88a81b1f3?narHash=sha256-5xA2D%2BiOEMoKBcTSbQe8Ztao5APX7C3eVeiFAdCg3WM%3D' (2026-04-21)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/9e5716a9dbf7dbf9622a95a5bd23a898867759c6?narHash=sha256-%2BhK%2BEgAwuRG%2BlhqwOkKfXlqMEdELIoTMdjfVosIlLb0%3D' (2026-04-18)
  → 'github:YaLTeR/niri/e472b5b0f13d91fdf0e5d07551f68177d25043d0?narHash=sha256-8UFcj0LV4zZ0gTX96LlbzpmBfYkoXsfb3ETg7GeRup8%3D' (2026-04-21)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/c7f47036d3df2add644c46d712d14262b7d86c0c?narHash=sha256-gyqXNMgk3sh%2BogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk%3D' (2026-04-17)
  → 'github:NixOS/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/34a0df8a2bdee344e1d12c64c6d2eb4ec98bb4f9?narHash=sha256-PKN9Y9XH0lwPkKeQgWvtD/oO2HajSYA5CD2rxVBcFHQ%3D' (2026-04-18)
  → 'github:fufexan/nix-gaming/9fbfaf7ee04939f7f2fffc03094253c270b585b5?narHash=sha256-JvWRhIL%2BAL7CJCSgCwPFXMKzYRacIhHlb9nguFm/e3U%3D' (2026-04-21)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/13043924aaa7375ce482ebe2494338e058282925?narHash=sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90%3D' (2026-04-11)
  → 'github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b?narHash=sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw%3D' (2026-04-16)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bedba5989b04614fc598af9633033b95a937933f?narHash=sha256-7jt9Vpm48Yy5yAWigYpde%2BHxtYEpEuyzIQJF4VYehhk%3D' (2026-04-12)
  → 'github:nix-community/nix-index-database/c43246d4e9e506178b69baed075d797ec2d873e2?narHash=sha256-oHVcvP2Ahhj1KUsEzp%2B2BQF55/r5VSa3QxdPdwE1p00%3D' (2026-04-22)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c7f47036d3df2add644c46d712d14262b7d86c0c?narHash=sha256-gyqXNMgk3sh%2BogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk%3D' (2026-04-17)
  → 'github:NixOS/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9?narHash=sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM%3D' (2026-04-14)
  → 'github:NixOS/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc?narHash=sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24%3D' (2026-04-18)
• Updated input 'nur':
    'github:nix-community/NUR/e423fa37d5d2969be81bdc77693fbc89c1a4156f?narHash=sha256-CsxC5eUJSErYtgpn3eXOFXgZHpBU3MmjmsCenL4l8BQ%3D' (2026-04-18)
  → 'github:nix-community/NUR/daed3a795bd1df6f8c0e060ab3fdf2a8820d0653?narHash=sha256-G3keSZS%2BI6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM%3D' (2026-04-22)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=fb08eced449e87e47321e95beeb890a63d2c67bd' (2026-04-13)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=d60498adc038526b3d155e8ad61e51e78e6e32eb' (2026-04-21)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d4971dd58c6627bfee52a1ad4237637c0a2fb0cd?narHash=sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M%3D' (2026-04-13)
  → 'github:Mic92/sops-nix/bef289e2248991f7afeb95965c82fbcd8ff72598?narHash=sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI%3D' (2026-04-21)
```