### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776796985,
-        "narHash": "sha256-cNFg3H09sBZl1v9ds6PDHfLCUTDJbefGMSv+WxFs+9c=",
+        "lastModified": 1777054238,
+        "narHash": "sha256-qaqHPZO3oQJiIZgD6sp5HKwvYAVyMtHVJiXVwPSEkx0=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "ac5956bbceb022998fc1dd0001322f10ef1e6dda",
+        "rev": "acb94409639d6d6d64bea140f939ac34938560b1",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1776792814,
-        "narHash": "sha256-39dlIhz9KxUNQFxGpE9SvCviaOWAivdW0XJM8RnPNmg=",
+        "lastModified": 1777002108,
+        "narHash": "sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "d7d558d0b2e239e27b40bcf1af6fe12e323aa391",
+        "rev": "46476ae2538db486462aef8a9de37d19030cdaf2",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776608760,
-        "narHash": "sha256-ehDv8bF7k/2Kf4b8CCoSm51U/MOoFuLsRXqe5wZ57sE=",
+        "lastModified": 1776881435,
+        "narHash": "sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "7e06e29005853bbaaa3b1c1067f915d6e0db728a",
+        "rev": "1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1776799121,
-        "narHash": "sha256-G+qUbf2jZ14mbfJdtQVvW2XPWelmOR4BaG9m4SUWIck=",
+        "lastModified": 1777092033,
+        "narHash": "sha256-pwLe5q103VntHpINHnfD3EMPkIMopmRxPB7uB3BwSGE=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "c6ed64b24e414cd4b9588b645a6345b15fa697f4",
+        "rev": "a459b7d1b4331bb22a5c9d7e62b7ea8a788bc4d2",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776821429,
-        "narHash": "sha256-A9BhLm0dyfAlCM7b1NMDx/fLN/m8V//ihrnMMkLiCR4=",
+        "lastModified": 1777041352,
+        "narHash": "sha256-aQ5QsWtbuiPMMGH+oWf+NaW+Go7hahqOWoLp/0V1Z3Q=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "956cea9b7bb01346ebeebbac512aa71b90fd1365",
+        "rev": "622f25235ec0969479c1d03247ef15c8bc07cee9",
         "type": "github"
       },
       "original": {
@@ -818,11 +818,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776777932,
-        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "lastModified": 1777086106,
+        "narHash": "sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "rev": "5826802354a74af18540aef0b01bc1320f82cc17",
         "type": "github"
       },
       "original": {
@@ -953,11 +953,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1776805766,
-        "narHash": "sha256-IVUzmEflwGk02ZAuBBc3h0gWu/p2c9H+cg//dgWlFBg=",
+        "lastModified": 1777040476,
+        "narHash": "sha256-BEzeFZYo9J3wgKbtBhIhiK46NsRqvyEzN/euJq78Wco=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "019dac7a0560145d7a557005a21a7fe48ecabe3e",
+        "rev": "e3c9b64812042ade8bec47499f461f2c7d36c184",
         "type": "github"
       },
       "original": {
@@ -1483,11 +1483,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1776805172,
-        "narHash": "sha256-5xA2D+iOEMoKBcTSbQe8Ztao5APX7C3eVeiFAdCg3WM=",
+        "lastModified": 1777118280,
+        "narHash": "sha256-xCSQxApbEq2cQuS1uvUCTUHL4masVOjexi8zv36peo0=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "035f8ef8a0a5ec8f226231b15e84ebd88a81b1f3",
+        "rev": "4a4a4da68a0e420e013fc125f522ee1f0c0dd252",
         "type": "github"
       },
       "original": {
@@ -1537,11 +1537,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1776800113,
-        "narHash": "sha256-8UFcj0LV4zZ0gTX96LlbzpmBfYkoXsfb3ETg7GeRup8=",
+        "lastModified": 1777115661,
+        "narHash": "sha256-RTVipdr4vxnOyt/4xPBHz/BAWZYIeZ1VxnsJsjJp/Uc=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "e472b5b0f13d91fdf0e5d07551f68177d25043d0",
+        "rev": "91be662ac6cff43a010395352afbe8a50e3a18af",
         "type": "github"
       },
       "original": {
@@ -1573,11 +1573,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1776741712,
-        "narHash": "sha256-JvWRhIL+AL7CJCSgCwPFXMKzYRacIhHlb9nguFm/e3U=",
+        "lastModified": 1777085676,
+        "narHash": "sha256-bqNVPSDWL0HI0CW6U7s6KDvcbXjJTJChxFNn9VqHIV8=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "9fbfaf7ee04939f7f2fffc03094253c270b585b5",
+        "rev": "07af1bfee086353976eec0e3e2d5f6292257ced2",
         "type": "github"
       },
       "original": {
@@ -1651,11 +1651,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776750258,
-        "narHash": "sha256-jab3OFEK7MpiAolaLBjvIxdf258UWvvusWxPJPE5ito=",
+        "lastModified": 1777014002,
+        "narHash": "sha256-x6BrXhfnsM2SG/n00O5o1Azn2txRHxU4cCZXiDZkFxU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d73c2809cb39eecce6284c38100e69a6064e5d9",
+        "rev": "15ebe06759175c2e98dba23c0b125913589094e7",
         "type": "github"
       },
       "original": {
@@ -1727,11 +1727,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
@@ -1759,11 +1759,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -1903,11 +1903,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
@@ -1941,11 +1941,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776829882,
-        "narHash": "sha256-G3keSZS+I6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM=",
+        "lastModified": 1777117319,
+        "narHash": "sha256-ps0FuCMjzuvzAzzeE8LjNu5xE0JI7deTB6PI+emTU8w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daed3a795bd1df6f8c0e060ab3fdf2a8820d0653",
+        "rev": "3b6f81126c44494fdfb3ade8a3f2844f5b6f3fb9",
         "type": "github"
       },
       "original": {
@@ -2058,16 +2058,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1766725085,
-        "narHash": "sha256-O2aMFdDUYJazFrlwL7aSIHbUSEm3ADVZjmf41uBJfHs=",
+        "lastModified": 1776854048,
+        "narHash": "sha256-lLbV66V3RMNp1l8/UelmR4YzoJ5ONtgvEtiUMJATH/o=",
         "ref": "refs/heads/master",
-        "rev": "41828c4180fb921df7992a5405f5ff05d2ac2fff",
-        "revCount": 715,
+        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
+        "revCount": 806,
         "type": "git",
         "url": "https://git.outfoxxed.me/quickshell/quickshell"
       },
       "original": {
-        "rev": "41828c4180fb921df7992a5405f5ff05d2ac2fff",
+        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
         "type": "git",
         "url": "https://git.outfoxxed.me/quickshell/quickshell"
       }
@@ -2079,11 +2079,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776761300,
-        "narHash": "sha256-0CTVYyznIl8QC6PpMoOSM2Qo4sIdHp3j3wV8lU7wON8=",
+        "lastModified": 1777089709,
+        "narHash": "sha256-bZoy6qxL6Dbptt6PABvuhGKbyjuoyI7SQ1tzxM9g/QM=",
         "ref": "master",
-        "rev": "d60498adc038526b3d155e8ad61e51e78e6e32eb",
-        "revCount": 804,
+        "rev": "11a71d233a566caba4ddffdca2e41d1fa79e45b1",
+        "revCount": 808,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/ac5956bbceb022998fc1dd0001322f10ef1e6dda?narHash=sha256-cNFg3H09sBZl1v9ds6PDHfLCUTDJbefGMSv%2BWxFs%2B9c%3D' (2026-04-21)
  → 'github:xddxdd/nix-cachyos-kernel/acb94409639d6d6d64bea140f939ac34938560b1?narHash=sha256-qaqHPZO3oQJiIZgD6sp5HKwvYAVyMtHVJiXVwPSEkx0%3D' (2026-04-24)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/7e06e29005853bbaaa3b1c1067f915d6e0db728a?narHash=sha256-ehDv8bF7k/2Kf4b8CCoSm51U/MOoFuLsRXqe5wZ57sE%3D' (2026-04-19)
  → 'github:CachyOS/linux-cachyos/1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340?narHash=sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs%3D' (2026-04-22)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/d7d558d0b2e239e27b40bcf1af6fe12e323aa391?narHash=sha256-39dlIhz9KxUNQFxGpE9SvCviaOWAivdW0XJM8RnPNmg%3D' (2026-04-21)
  → 'github:CachyOS/kernel-patches/46476ae2538db486462aef8a9de37d19030cdaf2?narHash=sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs%3D' (2026-04-24)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/8d73c2809cb39eecce6284c38100e69a6064e5d9?narHash=sha256-jab3OFEK7MpiAolaLBjvIxdf258UWvvusWxPJPE5ito%3D' (2026-04-21)
  → 'github:NixOS/nixpkgs/15ebe06759175c2e98dba23c0b125913589094e7?narHash=sha256-x6BrXhfnsM2SG/n00O5o1Azn2txRHxU4cCZXiDZkFxU%3D' (2026-04-24)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/c6ed64b24e414cd4b9588b645a6345b15fa697f4?narHash=sha256-G%2BqUbf2jZ14mbfJdtQVvW2XPWelmOR4BaG9m4SUWIck%3D' (2026-04-21)
  → 'github:AvengeMedia/DankMaterialShell/a459b7d1b4331bb22a5c9d7e62b7ea8a788bc4d2?narHash=sha256-pwLe5q103VntHpINHnfD3EMPkIMopmRxPB7uB3BwSGE%3D' (2026-04-25)
• Updated input 'dank-material-shell/quickshell':
    'git+https://git.outfoxxed.me/quickshell/quickshell?ref=refs/heads/master&rev=41828c4180fb921df7992a5405f5ff05d2ac2fff' (2025-12-26)
  → 'git+https://git.outfoxxed.me/quickshell/quickshell?ref=refs/heads/master&rev=783c953987dc56ff0601abe6845ed96f1d00495a' (2026-04-22)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/956cea9b7bb01346ebeebbac512aa71b90fd1365?narHash=sha256-A9BhLm0dyfAlCM7b1NMDx/fLN/m8V//ihrnMMkLiCR4%3D' (2026-04-22)
  → 'github:AvengeMedia/dms-plugin-registry/622f25235ec0969479c1d03247ef15c8bc07cee9?narHash=sha256-aQ5QsWtbuiPMMGH%2BoWf%2BNaW%2BGo7hahqOWoLp/0V1Z3Q%3D' (2026-04-24)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/5d5640599a0050b994330328b9fd45709c909720?narHash=sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8%3D' (2026-04-21)
  → 'github:nix-community/home-manager/5826802354a74af18540aef0b01bc1320f82cc17?narHash=sha256-hlNpIN18pw3xo34Lsrp6vAMUPn0aB/zFBqL0QXI1Pmk%3D' (2026-04-25)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/019dac7a0560145d7a557005a21a7fe48ecabe3e?narHash=sha256-IVUzmEflwGk02ZAuBBc3h0gWu/p2c9H%2Bcg//dgWlFBg%3D' (2026-04-21)
  → 'github:hyprwm/Hyprland/e3c9b64812042ade8bec47499f461f2c7d36c184?narHash=sha256-BEzeFZYo9J3wgKbtBhIhiK46NsRqvyEzN/euJq78Wco%3D' (2026-04-24)
• Updated input 'niri':
    'github:sodiboo/niri-flake/035f8ef8a0a5ec8f226231b15e84ebd88a81b1f3?narHash=sha256-5xA2D%2BiOEMoKBcTSbQe8Ztao5APX7C3eVeiFAdCg3WM%3D' (2026-04-21)
  → 'github:sodiboo/niri-flake/4a4a4da68a0e420e013fc125f522ee1f0c0dd252?narHash=sha256-xCSQxApbEq2cQuS1uvUCTUHL4masVOjexi8zv36peo0%3D' (2026-04-25)
• Updated input 'niri/niri-unstable':
    'github:YaLTeR/niri/e472b5b0f13d91fdf0e5d07551f68177d25043d0?narHash=sha256-8UFcj0LV4zZ0gTX96LlbzpmBfYkoXsfb3ETg7GeRup8%3D' (2026-04-21)
  → 'github:YaLTeR/niri/91be662ac6cff43a010395352afbe8a50e3a18af?narHash=sha256-RTVipdr4vxnOyt/4xPBHz/BAWZYIeZ1VxnsJsjJp/Uc%3D' (2026-04-25)
• Updated input 'niri/nixpkgs-stable':
    'github:NixOS/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
  → 'github:NixOS/nixpkgs/10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac?narHash=sha256-vl3dkhlE5gzsItuHoEMVe%2BDlonsK%2B0836LIRDnm6MXQ%3D' (2026-04-21)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/9fbfaf7ee04939f7f2fffc03094253c270b585b5?narHash=sha256-JvWRhIL%2BAL7CJCSgCwPFXMKzYRacIhHlb9nguFm/e3U%3D' (2026-04-21)
  → 'github:fufexan/nix-gaming/07af1bfee086353976eec0e3e2d5f6292257ced2?narHash=sha256-bqNVPSDWL0HI0CW6U7s6KDvcbXjJTJChxFNn9VqHIV8%3D' (2026-04-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
  → 'github:NixOS/nixpkgs/10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac?narHash=sha256-vl3dkhlE5gzsItuHoEMVe%2BDlonsK%2B0836LIRDnm6MXQ%3D' (2026-04-21)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc?narHash=sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24%3D' (2026-04-18)
  → 'github:NixOS/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57?narHash=sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI%3D' (2026-04-22)
• Updated input 'nur':
    'github:nix-community/NUR/daed3a795bd1df6f8c0e060ab3fdf2a8820d0653?narHash=sha256-G3keSZS%2BI6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM%3D' (2026-04-22)
  → 'github:nix-community/NUR/3b6f81126c44494fdfb3ade8a3f2844f5b6f3fb9?narHash=sha256-ps0FuCMjzuvzAzzeE8LjNu5xE0JI7deTB6PI%2BemTU8w%3D' (2026-04-25)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=d60498adc038526b3d155e8ad61e51e78e6e32eb' (2026-04-21)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=11a71d233a566caba4ddffdca2e41d1fa79e45b1' (2026-04-25)```