### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776876344,
-        "narHash": "sha256-Ubqb/agkuMJK+k19gjQgHux/eOYRc1sRGoOZOho8+VY=",
+        "lastModified": 1777499565,
+        "narHash": "sha256-nU55VWk99Pn1QzQDDjFISocC4SgDZ3Xp+zb6ji3JclM=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "648a13d0ee1e03a843b3e145b8ece15393058701",
+        "rev": "813c1e8981893c11e118b19c125d6bc282f51765",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777227006,
-        "narHash": "sha256-A7GcOXjfo2xmZ3ERgN0j6GcqaVzqIf5zpYQcdfDaMr0=",
+        "lastModified": 1778258588,
+        "narHash": "sha256-24ij+y6nPKH3FAwkykI4Hy2kTiL/sBHSHCoIzlSeQsc=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "0f7e2bea4088227a80502557f6c0e3b74949d6b5",
+        "rev": "8adff7983c2fcb0af530a4ac6165b3431bfbb09c",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1777002108,
-        "narHash": "sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs=",
+        "lastModified": 1777876120,
+        "narHash": "sha256-fdFgVCoua3rsQyyHkgxcnwi0hUktR8UtcI/suS8jcbg=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "46476ae2538db486462aef8a9de37d19030cdaf2",
+        "rev": "e80ce8172953b8c199daf6a2850974bb12731ae9",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776881435,
-        "narHash": "sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs=",
+        "lastModified": 1778227630,
+        "narHash": "sha256-IZIpCvjTLn6dzgFa6vOB6rUkMp3gktQy8suVXkPfvSg=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340",
+        "rev": "24da68625ce48a4ea1b28996050f1229e7bc78a2",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1777675128,
-        "narHash": "sha256-2zuDs9Lju99dg8MsSPf1frKPPgCRakDn+CEGX71cHJ0=",
+        "lastModified": 1778306063,
+        "narHash": "sha256-+Y7R7ez8GjQ5oxNeh9Raa2b8t+AQ2jOnWZRTA/h58LE=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "c1cbd0994f5a3585dded85069f2c9103c54f5285",
+        "rev": "cf641b4e0845210dbf05fcfe13c4564897d73cbf",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777686876,
-        "narHash": "sha256-Jcxsfaebu+RzO4igAi1xDg3+XVJgm2+msUF0P8PlmQg=",
+        "lastModified": 1778325528,
+        "narHash": "sha256-+y7QsGE8e6AofulVXhMckNrHkNOWfIKrysGwsmk/7pE=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "b7856c76e5d8733a4c6ffe2e453e2bcb1ab3b351",
+        "rev": "5adbbbe54a39c3efdf3ae33ef735813537c5d95c",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775425411,
-        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
         "type": "github"
       },
       "original": {
@@ -818,11 +818,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777679572,
-        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
+        "lastModified": 1778248595,
+        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
+        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
         "type": "github"
       },
       "original": {
@@ -953,11 +953,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777677995,
-        "narHash": "sha256-Q1fYHq1Gn79sQAkUDALR6dEC6l2WLkFyaB0cZLZnMQM=",
+        "lastModified": 1778325754,
+        "narHash": "sha256-GI8McFf7ZGs0YGMC2vKRpkWzN4Rj87yk4E1fDkxWcxM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "c065e951d631a3aa3736b45f17b3556597f63c1a",
+        "rev": "11bd00cd18bb3178f5887b247d9be1d4fd269081",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777392029,
-        "narHash": "sha256-iTtzJsp4hXp7/Y+2kVaosPPNBeUJbFiqQcZVRUtC+dM=",
+        "lastModified": 1778254455,
+        "narHash": "sha256-hwtKSJcroZ++QAb9rI9L6Sp3XJlDIyWZN7UOVMiN8jY=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "473804b3594dd829295484f1f479a560b8114f2d",
+        "rev": "22de29bc1cf4126202df52691d0bc9a065089cba",
         "type": "github"
       },
       "original": {
@@ -1082,11 +1082,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426736,
-        "narHash": "sha256-rl7i4aY+9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0=",
+        "lastModified": 1777320127,
+        "narHash": "sha256-Qu+Wf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "7833ff33b2e82d3406337b5dcf0d1cec595d83e9",
+        "rev": "090117506ddc3d7f26e650ff344d378c2ec329cc",
         "type": "github"
       },
       "original": {
@@ -1159,11 +1159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777492286,
-        "narHash": "sha256-PwuoEJQcjSKJNP5T55qhfDwIP0tw5zxEhfu8GDfKfeg=",
+        "lastModified": 1778234770,
+        "narHash": "sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "ec5c0c709706bad5b82f667fd8758eae442577ce",
+        "rev": "a2dbd8a4cc51f7cbe4224732668392bb1aa79df2",
         "type": "github"
       },
       "original": {
@@ -1184,11 +1184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777148232,
-        "narHash": "sha256-Uv0WZLhu89SafuSOmYDA7akrPt4wBRmsa1ucasO5aXg=",
+        "lastModified": 1777159683,
+        "narHash": "sha256-Jxixw6wZphUp+nHYxOKUYSckL17QMBx2d5Zp0rJHr1g=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "fec9cf1abcc1011e46f0a0986f46bf93c6bf8b92",
+        "rev": "b8632713a6beaf28b56f2a7b0ab2fb7088dbb404",
         "type": "github"
       },
       "original": {
@@ -1213,11 +1213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776728575,
-        "narHash": "sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU=",
+        "lastModified": 1777388329,
+        "narHash": "sha256-40YxVGF2rA9iH3D7am5fy4EOSBbMgpJtJ9yhl0Cx+qI=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "f3a80888783702a39691b684d099e16b83ed4702",
+        "rev": "04be2897e05f9b271d532b5ae56ca088d2eeac02",
         "type": "github"
       },
       "original": {
@@ -1478,11 +1478,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1778026792,
-        "narHash": "sha256-cWOdvSUyekAWxxczYAOMANXeegArqwd7Bef6GdfYD1E=",
+        "lastModified": 1778260783,
+        "narHash": "sha256-H3EyTR+IXZg+njuF9OxOqsL9Ruj5Ww4hKCBfs7ztkuo=",
         "ref": "refs/heads/main",
-        "rev": "78cda42342d25aff49abdbcba7d376ff55e352b2",
-        "revCount": 106,
+        "rev": "f2d80c489d7145f3d6fa3158b92eb994a16d8b2a",
+        "revCount": 110,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1515,11 +1515,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1778009434,
-        "narHash": "sha256-kbT+bAdT8U1KRPVwwXpTCLQuRzER2yIkiv2E9/F/jhw=",
+        "lastModified": 1778182593,
+        "narHash": "sha256-gR61WP2SBNu1EQ8Rkqw2VD8Ec1oLJHFrwgll2N/xJD4=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "56654034e9a9b74f6fcf268ebfe114a8c74a8c0b",
+        "rev": "90366886b268ddb2b32779422fa0dce379dca312",
         "type": "github"
       },
       "original": {
@@ -1551,11 +1551,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1777538647,
-        "narHash": "sha256-pCdYLPCoZFUjTIOTto86MpJse/I0A8XHy3HIU53s/qM=",
+        "lastModified": 1778297703,
+        "narHash": "sha256-EqS67I6LgEpnu/rUO6x+SaMWMN89TTsY1AnThsl84uI=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "9a1c5aeb3d0a96aa11f02c33fdba319ddb339aad",
+        "rev": "2c1b0276febd6b6cac789a9f3cafe5d6ef4e8f58",
         "type": "github"
       },
       "original": {
@@ -1571,11 +1571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777181277,
-        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
+        "lastModified": 1778240325,
+        "narHash": "sha256-d2HIS7LpfI0lgxiXCXLjxrHl3eIdNvAVexOu0xiM488=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+        "rev": "dd2d0e3f6ba00af01b9498f5697173bdc2524bee",
         "type": "github"
       },
       "original": {
@@ -1629,11 +1629,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777187199,
-        "narHash": "sha256-RJlLGrl+xHndIVK1NbPkIsItePNB3X4PIe8UTk3AHnw=",
+        "lastModified": 1778228972,
+        "narHash": "sha256-L34YTBob9sdjnc+rd7nMC2X8ddw0LT4RfufnlFyArRU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "facea5e538604efa4893c08770fe9fca5bf62c2f",
+        "rev": "1c5503ba41146fb6b49ed9706823b30de7f3a78f",
         "type": "github"
       },
       "original": {
@@ -1645,11 +1645,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -1675,11 +1675,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -1721,11 +1721,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -1881,11 +1881,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
         "type": "github"
       },
       "original": {
@@ -1897,11 +1897,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {
@@ -1919,11 +1919,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777720359,
-        "narHash": "sha256-fH4uiqXKHdOk+52pK36LGXtwFSVl9i1bmlr6vufR69c=",
+        "lastModified": 1778328918,
+        "narHash": "sha256-gkbSjUjI06ivu0uqepw3dNdRDJLQYZsXw8MUnH8aeGE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c0ac8b038dfaa434555c0bee45b0d03847b35a9",
+        "rev": "433149e7945bf78e49c5b70e02e9e5f3ea0ee657",
         "type": "github"
       },
       "original": {
@@ -2057,11 +2057,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777706159,
-        "narHash": "sha256-TuD8hw9lkRCEb+6v93iB7HDvcmvH8R0qyD6wBmPGfv8=",
+        "lastModified": 1778222427,
+        "narHash": "sha256-6GFiP611nEJvtm+m03sMyfaVIJ9QOCi//hS+PPKyyPA=",
         "ref": "master",
-        "rev": "8db8ca1fecfcce8def1f9265fa1742baa0e0c271",
-        "revCount": 813,
+        "rev": "d1760ed1f31c02a95b37a9bf4084129c829ebe7f",
+        "revCount": 817,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -2198,11 +2198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777338324,
-        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {
@@ -2540,11 +2540,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777035886,
-        "narHash": "sha256-m1TNuBoSXUBSKhD9UVMkU90M0wFTPTfvIOOltO8IM8A=",
+        "lastModified": 1777585783,
+        "narHash": "sha256-JTeWRy42VElroJ0rVdZuVXSoTLsx+NzQfGPKMbtn3SU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "ecfcdcc781f48821d83e1e2a0e30d7beca0eeb5e",
+        "rev": "fa50d6fbaff8f42c61071b87b034a90d82a33558",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/0f7e2bea4088227a80502557f6c0e3b74949d6b5?narHash=sha256-A7GcOXjfo2xmZ3ERgN0j6GcqaVzqIf5zpYQcdfDaMr0%3D' (2026-04-26)
  → 'github:xddxdd/nix-cachyos-kernel/8adff7983c2fcb0af530a4ac6165b3431bfbb09c?narHash=sha256-24ij%2By6nPKH3FAwkykI4Hy2kTiL/sBHSHCoIzlSeQsc%3D' (2026-05-08)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340?narHash=sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs%3D' (2026-04-22)
  → 'github:CachyOS/linux-cachyos/24da68625ce48a4ea1b28996050f1229e7bc78a2?narHash=sha256-IZIpCvjTLn6dzgFa6vOB6rUkMp3gktQy8suVXkPfvSg%3D' (2026-05-08)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/46476ae2538db486462aef8a9de37d19030cdaf2?narHash=sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs%3D' (2026-04-24)
  → 'github:CachyOS/kernel-patches/e80ce8172953b8c199daf6a2850974bb12731ae9?narHash=sha256-fdFgVCoua3rsQyyHkgxcnwi0hUktR8UtcI/suS8jcbg%3D' (2026-05-04)
• Updated input 'cachyos-kernel/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/0678d8986be1661af6bb555f3489f2fdfc31f6ff?narHash=sha256-qIoWPDs%2B0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ%3D' (2026-05-05)
• Updated input 'cachyos-kernel/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a?narHash=sha256-%2BU7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ%3D' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/facea5e538604efa4893c08770fe9fca5bf62c2f?narHash=sha256-RJlLGrl%2BxHndIVK1NbPkIsItePNB3X4PIe8UTk3AHnw%3D' (2026-04-26)
  → 'github:NixOS/nixpkgs/1c5503ba41146fb6b49ed9706823b30de7f3a78f?narHash=sha256-L34YTBob9sdjnc%2Brd7nMC2X8ddw0LT4RfufnlFyArRU%3D' (2026-05-08)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/c1cbd0994f5a3585dded85069f2c9103c54f5285?narHash=sha256-2zuDs9Lju99dg8MsSPf1frKPPgCRakDn%2BCEGX71cHJ0%3D' (2026-05-01)
  → 'github:AvengeMedia/DankMaterialShell/cf641b4e0845210dbf05fcfe13c4564897d73cbf?narHash=sha256-%2BY7R7ez8GjQ5oxNeh9Raa2b8t%2BAQ2jOnWZRTA/h58LE%3D' (2026-05-09)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/b7856c76e5d8733a4c6ffe2e453e2bcb1ab3b351?narHash=sha256-Jcxsfaebu%2BRzO4igAi1xDg3%2BXVJgm2%2BmsUF0P8PlmQg%3D' (2026-05-02)
  → 'github:AvengeMedia/dms-plugin-registry/5adbbbe54a39c3efdf3ae33ef735813537c5d95c?narHash=sha256-%2By7QsGE8e6AofulVXhMckNrHkNOWfIKrysGwsmk/7pE%3D' (2026-05-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0d02ec1d0a05f88ef9e74b516842900c41f0f2fe?narHash=sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo%3D' (2026-04-05)
  → 'github:nix-community/home-manager/cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5?narHash=sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8%3D' (2026-05-03)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/9cb587ade2aa1b4a7257f0238d41072690b0ca4f?narHash=sha256-egYNbRrkn%2B6SwTHinhdb6WUfzzdC3nXfCRqS321VylY%3D' (2026-05-01)
  → 'github:nix-community/home-manager/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d?narHash=sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc%3D' (2026-05-08)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/c065e951d631a3aa3736b45f17b3556597f63c1a?narHash=sha256-Q1fYHq1Gn79sQAkUDALR6dEC6l2WLkFyaB0cZLZnMQM%3D' (2026-05-01)
  → 'github:hyprwm/Hyprland/11bd00cd18bb3178f5887b247d9be1d4fd269081?narHash=sha256-GI8McFf7ZGs0YGMC2vKRpkWzN4Rj87yk4E1fDkxWcxM%3D' (2026-05-09)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/648a13d0ee1e03a843b3e145b8ece15393058701?narHash=sha256-Ubqb/agkuMJK%2Bk19gjQgHux/eOYRc1sRGoOZOho8%2BVY%3D' (2026-04-22)
  → 'github:hyprwm/aquamarine/813c1e8981893c11e118b19c125d6bc282f51765?narHash=sha256-nU55VWk99Pn1QzQDDjFISocC4SgDZ3Xp%2Bzb6ji3JclM%3D' (2026-04-29)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/7833ff33b2e82d3406337b5dcf0d1cec595d83e9?narHash=sha256-rl7i4aY%2B9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0%3D' (2026-04-17)
  → 'github:hyprwm/hyprlang/090117506ddc3d7f26e650ff344d378c2ec329cc?narHash=sha256-Qu%2BWf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U%3D' (2026-04-27)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/ec5c0c709706bad5b82f667fd8758eae442577ce?narHash=sha256-PwuoEJQcjSKJNP5T55qhfDwIP0tw5zxEhfu8GDfKfeg%3D' (2026-04-29)
  → 'github:hyprwm/hyprutils/a2dbd8a4cc51f7cbe4224732668392bb1aa79df2?narHash=sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE%3D' (2026-05-08)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/fec9cf1abcc1011e46f0a0986f46bf93c6bf8b92?narHash=sha256-Uv0WZLhu89SafuSOmYDA7akrPt4wBRmsa1ucasO5aXg%3D' (2026-04-25)
  → 'github:hyprwm/hyprwayland-scanner/b8632713a6beaf28b56f2a7b0ab2fb7088dbb404?narHash=sha256-Jxixw6wZphUp%2BnHYxOKUYSckL17QMBx2d5Zp0rJHr1g%3D' (2026-04-25)
• Updated input 'hyprland/hyprwire':
    'github:hyprwm/hyprwire/f3a80888783702a39691b684d099e16b83ed4702?narHash=sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU%3D' (2026-04-20)
  → 'github:hyprwm/hyprwire/04be2897e05f9b271d532b5ae56ca088d2eeac02?narHash=sha256-40YxVGF2rA9iH3D7am5fy4EOSBbMgpJtJ9yhl0Cx%2BqI%3D' (2026-04-28)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/ecfcdcc781f48821d83e1e2a0e30d7beca0eeb5e?narHash=sha256-m1TNuBoSXUBSKhD9UVMkU90M0wFTPTfvIOOltO8IM8A%3D' (2026-04-24)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/fa50d6fbaff8f42c61071b87b034a90d82a33558?narHash=sha256-JTeWRy42VElroJ0rVdZuVXSoTLsx%2BNzQfGPKMbtn3SU%3D' (2026-04-30)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/473804b3594dd829295484f1f479a560b8114f2d?narHash=sha256-iTtzJsp4hXp7/Y%2B2kVaosPPNBeUJbFiqQcZVRUtC%2BdM%3D' (2026-04-28)
  → 'github:hyprwm/hyprland-plugins/22de29bc1cf4126202df52691d0bc9a065089cba?narHash=sha256-hwtKSJcroZ%2B%2BQAb9rI9L6Sp3XJlDIyWZN7UOVMiN8jY%3D' (2026-05-08)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=78cda42342d25aff49abdbcba7d376ff55e352b2' (2026-05-06)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=f2d80c489d7145f3d6fa3158b92eb994a16d8b2a' (2026-05-08)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/56654034e9a9b74f6fcf268ebfe114a8c74a8c0b?narHash=sha256-kbT%2BbAdT8U1KRPVwwXpTCLQuRzER2yIkiv2E9/F/jhw%3D' (2026-05-05)
  → 'github:YaLTeR/niri/90366886b268ddb2b32779422fa0dce379dca312?narHash=sha256-gR61WP2SBNu1EQ8Rkqw2VD8Ec1oLJHFrwgll2N/xJD4%3D' (2026-05-07)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/9a1c5aeb3d0a96aa11f02c33fdba319ddb339aad?narHash=sha256-pCdYLPCoZFUjTIOTto86MpJse/I0A8XHy3HIU53s/qM%3D' (2026-04-30)
  → 'github:fufexan/nix-gaming/2c1b0276febd6b6cac789a9f3cafe5d6ef4e8f58?narHash=sha256-EqS67I6LgEpnu/rUO6x%2BSaMWMN89TTsY1AnThsl84uI%3D' (2026-05-09)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/5250617bffd85403b14dbf43c3870e7f255d2c16?narHash=sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT%2BIPhcsukVbgk%3D' (2026-05-01)
• Updated input 'nix-gaming/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a?narHash=sha256-%2BU7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ%3D' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30?narHash=sha256-GMSVw35Q%2B294GlrTUKlx087E31z7KurReQ1YHSKp5iw%3D' (2026-04-23)
  → 'github:NixOS/nixpkgs/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0?narHash=sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk%3D' (2026-05-01)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa?narHash=sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8%3D' (2026-04-26)
  → 'github:nix-community/nix-index-database/dd2d0e3f6ba00af01b9498f5697173bdc2524bee?narHash=sha256-d2HIS7LpfI0lgxiXCXLjxrHl3eIdNvAVexOu0xiM488%3D' (2026-05-08)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
  → 'github:NixOS/nixpkgs/0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5?narHash=sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA%3D' (2026-05-05)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D' (2026-04-30)
  → 'github:NixOS/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1?narHash=sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9%2BhrDTkDU%3D' (2026-05-05)
• Updated input 'nur':
    'github:nix-community/NUR/6c0ac8b038dfaa434555c0bee45b0d03847b35a9?narHash=sha256-fH4uiqXKHdOk%2B52pK36LGXtwFSVl9i1bmlr6vufR69c%3D' (2026-05-02)
  → 'github:nix-community/NUR/433149e7945bf78e49c5b70e02e9e5f3ea0ee657?narHash=sha256-gkbSjUjI06ivu0uqepw3dNdRDJLQYZsXw8MUnH8aeGE%3D' (2026-05-09)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=8db8ca1fecfcce8def1f9265fa1742baa0e0c271' (2026-05-02)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=d1760ed1f31c02a95b37a9bf4084129c829ebe7f' (2026-05-08)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8eaee5c45428b28b8c47a83e4c09dccec5f279b5?narHash=sha256-bc%2BZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E%3D' (2026-04-28)
  → 'github:Mic92/sops-nix/c591bf665727040c6cc5cb409079acb22dcce33c?narHash=sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8%3D' (2026-05-05)```