### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776876344,
-        "narHash": "sha256-Ubqb/agkuMJK+k19gjQgHux/eOYRc1sRGoOZOho8+VY=",
+        "lastModified": 1778620495,
+        "narHash": "sha256-Gu7UhWjwKCgSiVC3Qz/Rc7cYi9DNuDTBxYzg3kfLvfM=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "648a13d0ee1e03a843b3e145b8ece15393058701",
+        "rev": "be35f75ac305f430f5f9d89b5f5a4af59ca7567e",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775379895,
-        "narHash": "sha256-kmwC3PQQL2saPj2QihxHbbNDO1IvhVGbrECFvCqirrM=",
+        "lastModified": 1778395619,
+        "narHash": "sha256-MIk7wlhieFH2k0+KpsOb6/V/DyLkJRNhcymTjsTry1s=",
         "owner": "saatvik333",
         "repo": "wayland-bongocat",
-        "rev": "067e683ce73f5ca0f935f05794271d749a330c35",
+        "rev": "e140ceab744aeb8f2c327f9eef82121c03491b87",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777227006,
-        "narHash": "sha256-A7GcOXjfo2xmZ3ERgN0j6GcqaVzqIf5zpYQcdfDaMr0=",
+        "lastModified": 1778786644,
+        "narHash": "sha256-Nmacd0dSaHA6L35fTa6aXXoQUhoFa7+Z1k13Y9G3DPY=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "0f7e2bea4088227a80502557f6c0e3b74949d6b5",
+        "rev": "f2004296fc7cf75fccfa1028a6253dd5f42456a8",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1777002108,
-        "narHash": "sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs=",
+        "lastModified": 1778649239,
+        "narHash": "sha256-dNaGAK1lcop+yLsJzjlzSEF2YqBQYvIAKMxhaSqtxB0=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "46476ae2538db486462aef8a9de37d19030cdaf2",
+        "rev": "ba7b8b92f1906de3742dadcbe2d032b5275da891",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776881435,
-        "narHash": "sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs=",
+        "lastModified": 1778649404,
+        "narHash": "sha256-LwRT4Wn48IPn674TMnrckayCioF0iMGYqE7bi/256/k=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340",
+        "rev": "6544eeb1694d6790292156dc300f149d14bc5210",
         "type": "github"
       },
       "original": {
@@ -204,15 +204,14 @@
         "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "quickshell": "quickshell"
+        ]
       },
       "locked": {
-        "lastModified": 1777675128,
-        "narHash": "sha256-2zuDs9Lju99dg8MsSPf1frKPPgCRakDn+CEGX71cHJ0=",
+        "lastModified": 1778852883,
+        "narHash": "sha256-seaIGkMReVnJawQ3PZjzbKmQzuoIipQui+Be8bLUKes=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "c1cbd0994f5a3585dded85069f2c9103c54f5285",
+        "rev": "fbcc28785a2f42b17becf1d208d982cf218ede76",
         "type": "github"
       },
       "original": {
@@ -269,11 +268,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777686876,
-        "narHash": "sha256-Jcxsfaebu+RzO4igAi1xDg3+XVJgm2+msUF0P8PlmQg=",
+        "lastModified": 1778751506,
+        "narHash": "sha256-1uKZUme0C7vo3KSwlttK4l/0OWB/ktabKAD7kRHR5dE=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "b7856c76e5d8733a4c6ffe2e453e2bcb1ab3b351",
+        "rev": "fde8456bb08af0715041451592c461af66709b70",
         "type": "github"
       },
       "original": {
@@ -400,11 +399,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -436,11 +435,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -457,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -777,11 +776,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773550609,
-        "narHash": "sha256-neu7ixXHjV3LobVjOndkL97u+6UF6Yoh+CUnzX7kUBQ=",
+        "lastModified": 1776603440,
+        "narHash": "sha256-wA+ONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "554f6ed448ca74c00aa2371cde901ae1e73005b9",
+        "rev": "e2456ee419f9d75f8382e3d6c5af4690b316a5a8",
         "type": "github"
       },
       "original": {
@@ -797,11 +796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775425411,
-        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "lastModified": 1778905220,
+        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
         "type": "github"
       },
       "original": {
@@ -818,11 +817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777679572,
-        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
+        "lastModified": 1778921576,
+        "narHash": "sha256-jgIbBcGgKTtkp+lBas29hNFUU1t5O/2+GFvUjbiG0vM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
+        "rev": "32b42d71b4b22c4465963285bb6e462d7c93d45e",
         "type": "github"
       },
       "original": {
@@ -953,11 +952,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777677995,
-        "narHash": "sha256-Q1fYHq1Gn79sQAkUDALR6dEC6l2WLkFyaB0cZLZnMQM=",
+        "lastModified": 1778931952,
+        "narHash": "sha256-f/f0/RQ4aT2eeaiiydK/gZP5o1YWd2YrrJu0g/xQ7bk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "c065e951d631a3aa3736b45f17b3556597f63c1a",
+        "rev": "d56a9444c3a22dcf4981fd8f54508a098bac3971",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777392029,
-        "narHash": "sha256-iTtzJsp4hXp7/Y+2kVaosPPNBeUJbFiqQcZVRUtC+dM=",
+        "lastModified": 1778926589,
+        "narHash": "sha256-IX6e5ggQi60UChhDJx6wsczbPRCEE8WZbEtlDMazLmU=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "473804b3594dd829295484f1f479a560b8114f2d",
+        "rev": "f1569efa6a939fd68cee605d2a34d0db3af5d879",
         "type": "github"
       },
       "original": {
@@ -1082,11 +1081,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426736,
-        "narHash": "sha256-rl7i4aY+9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0=",
+        "lastModified": 1777320127,
+        "narHash": "sha256-Qu+Wf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "7833ff33b2e82d3406337b5dcf0d1cec595d83e9",
+        "rev": "090117506ddc3d7f26e650ff344d378c2ec329cc",
         "type": "github"
       },
       "original": {
@@ -1159,11 +1158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777492286,
-        "narHash": "sha256-PwuoEJQcjSKJNP5T55qhfDwIP0tw5zxEhfu8GDfKfeg=",
+        "lastModified": 1778234770,
+        "narHash": "sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "ec5c0c709706bad5b82f667fd8758eae442577ce",
+        "rev": "a2dbd8a4cc51f7cbe4224732668392bb1aa79df2",
         "type": "github"
       },
       "original": {
@@ -1184,11 +1183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777148232,
-        "narHash": "sha256-Uv0WZLhu89SafuSOmYDA7akrPt4wBRmsa1ucasO5aXg=",
+        "lastModified": 1777159683,
+        "narHash": "sha256-Jxixw6wZphUp+nHYxOKUYSckL17QMBx2d5Zp0rJHr1g=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "fec9cf1abcc1011e46f0a0986f46bf93c6bf8b92",
+        "rev": "b8632713a6beaf28b56f2a7b0ab2fb7088dbb404",
         "type": "github"
       },
       "original": {
@@ -1213,11 +1212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776728575,
-        "narHash": "sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU=",
+        "lastModified": 1778410714,
+        "narHash": "sha256-o6RzFj4nJXaPRY7EM01siuCQeT41RfwwmcmFQqwFJJg=",
         "owner": "hyprwm",
         "repo": "hyprwire",
-        "rev": "f3a80888783702a39691b684d099e16b83ed4702",
+        "rev": "85148a8e612808cf5ddb25d0b3c5840f3498a7dc",
         "type": "github"
       },
       "original": {
@@ -1478,11 +1477,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1778631446,
-        "narHash": "sha256-TxwnEDEButF84s1/0I/j3mXd5r6f0HIQOmveq1CZHc8=",
+        "lastModified": 1778890551,
+        "narHash": "sha256-963lknoQiISHEQc4IcmGpln7dkOzurhmv8XeHxVo2fI=",
         "ref": "refs/heads/main",
-        "rev": "2fab248459e27558f5fcf018603a18f64ae41f81",
-        "revCount": 114,
+        "rev": "4136a4c78342215ec3754da4fdddb90b8cd8ae86",
+        "revCount": 115,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1515,11 +1514,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1778389445,
-        "narHash": "sha256-9NyDMVf8ydUZGTzcPcLMQf0o1B3bte/00UGbuXHNWh8=",
+        "lastModified": 1778858756,
+        "narHash": "sha256-9VvAHNoi2wd0fxLfJOPChZMS7l6rhCtAJmpd59Hv5rw=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "38191826cb1e5fb9051a7e141fefe4941a2b4bed",
+        "rev": "cd5ac3e5e04bb5a11276d3c755fa25242818e05f",
         "type": "github"
       },
       "original": {
@@ -1551,11 +1550,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1777538647,
-        "narHash": "sha256-pCdYLPCoZFUjTIOTto86MpJse/I0A8XHy3HIU53s/qM=",
+        "lastModified": 1778730790,
+        "narHash": "sha256-g8+lQJL7OjgD1T+k6GzFC6LfHWc2gS0FFiO+MEIjZ9U=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "9a1c5aeb3d0a96aa11f02c33fdba319ddb339aad",
+        "rev": "2c555b88e541fb9da71d3c01f97d31ef1805d639",
         "type": "github"
       },
       "original": {
@@ -1571,11 +1570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777181277,
-        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
+        "lastModified": 1778393439,
+        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
         "type": "github"
       },
       "original": {
@@ -1614,11 +1613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776305949,
-        "narHash": "sha256-5Pqwqf4lEsZLZUcpefwMeq69d8hdirE83C5oWshBXo8=",
+        "lastModified": 1778725521,
+        "narHash": "sha256-7OCvTVOEEYlWwbHK+3+5pT3az07Dt4juYO4wdxiPGj4=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "b2bb4ab9d8e2457eeec3caa279b394525fbbe1a7",
+        "rev": "3ac3a6bbea994ebf5cc024d6288976a87c3986c1",
         "type": "github"
       },
       "original": {
@@ -1629,11 +1628,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777187199,
-        "narHash": "sha256-RJlLGrl+xHndIVK1NbPkIsItePNB3X4PIe8UTk3AHnw=",
+        "lastModified": 1778729098,
+        "narHash": "sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "facea5e538604efa4893c08770fe9fca5bf62c2f",
+        "rev": "39ea44cddd5060b8cd413ed5e13c6af61f302283",
         "type": "github"
       },
       "original": {
@@ -1645,11 +1644,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -1675,11 +1674,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -1721,11 +1720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -1881,11 +1880,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -1897,11 +1896,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {
@@ -1919,11 +1918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777720359,
-        "narHash": "sha256-fH4uiqXKHdOk+52pK36LGXtwFSVl9i1bmlr6vufR69c=",
+        "lastModified": 1778928309,
+        "narHash": "sha256-Ip1aeJq+v5B/UZCumsDP/uRadZkL/znNdiK3UNayYBQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c0ac8b038dfaa434555c0bee45b0d03847b35a9",
+        "rev": "65c51877443a1b3d63daabe7a696e6601df89caa",
         "type": "github"
       },
       "original": {
@@ -2015,11 +2014,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -2031,37 +2030,15 @@
     "quickshell": {
       "inputs": {
         "nixpkgs": [
-          "dank-material-shell",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776854048,
-        "narHash": "sha256-lLbV66V3RMNp1l8/UelmR4YzoJ5ONtgvEtiUMJATH/o=",
-        "ref": "refs/heads/master",
-        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
-        "revCount": 806,
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      },
-      "original": {
-        "rev": "783c953987dc56ff0601abe6845ed96f1d00495a",
-        "type": "git",
-        "url": "https://git.outfoxxed.me/quickshell/quickshell"
-      }
-    },
-    "quickshell_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777706159,
-        "narHash": "sha256-TuD8hw9lkRCEb+6v93iB7HDvcmvH8R0qyD6wBmPGfv8=",
+        "lastModified": 1778488696,
+        "narHash": "sha256-QSWgYuZUCNUJ/cxmaq83WkcT7lHQDDfsPVgH+96kIl0=",
         "ref": "master",
-        "rev": "8db8ca1fecfcce8def1f9265fa1742baa0e0c271",
-        "revCount": 813,
+        "rev": "7d1c9a9c6721606b129829134d6f614f015621e2",
+        "revCount": 818,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -2101,7 +2078,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "nvim-config": "nvim-config",
-        "quickshell": "quickshell_2",
+        "quickshell": "quickshell",
         "rust-system-scripts": "rust-system-scripts",
         "secrets": "secrets",
         "snowfall-lib": "snowfall-lib",
@@ -2198,11 +2175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777338324,
-        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {
@@ -2395,11 +2372,11 @@
     "tmux-dotbar": {
       "flake": false,
       "locked": {
-        "lastModified": 1771805838,
-        "narHash": "sha256-WaRKepmPqiE+W8Tm0dBc6hGiqqZP122eXjrG0rJnt0w=",
+        "lastModified": 1778528258,
+        "narHash": "sha256-CAKEN8Sk3t0nonV2R9df/DFTTUrVnbso0ZVGgeeGINM=",
         "owner": "vaaleyard",
         "repo": "tmux-dotbar",
-        "rev": "24a2e967e93ed7fd3688163436a2c0e4b2facc9a",
+        "rev": "f7dd0ff2b1302cbb59b826f0064a6aeb21f019eb",
         "type": "github"
       },
       "original": {
@@ -2540,11 +2517,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777035886,
-        "narHash": "sha256-m1TNuBoSXUBSKhD9UVMkU90M0wFTPTfvIOOltO8IM8A=",
+        "lastModified": 1778265244,
+        "narHash": "sha256-8jlPtGSsv/CQY6tVVyLF4Jjd0gnS+Zbn9yk/V13A9nM=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "ecfcdcc781f48821d83e1e2a0e30d7beca0eeb5e",
+        "rev": "813ea5ca9a1702a9a2d1f5836bc00172ef698968",
         "type": "github"
       },
       "original": {

--- a/homes/aarch64-darwin/derethil@hestia/default.nix
+++ b/homes/aarch64-darwin/derethil@hestia/default.nix
@@ -50,7 +50,7 @@ in {
         jira-cli = enabled;
         neovim = enabled;
         claude-code = enabled;
-        postgresql = enabled;
+        # postgresql = enabled; failing to build right now
       };
       nix = {
         manix = enabled;


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'bongocat':
    'github:saatvik333/wayland-bongocat/067e683ce73f5ca0f935f05794271d749a330c35?narHash=sha256-kmwC3PQQL2saPj2QihxHbbNDO1IvhVGbrECFvCqirrM%3D' (2026-04-05)
  → 'github:saatvik333/wayland-bongocat/e140ceab744aeb8f2c327f9eef82121c03491b87?narHash=sha256-MIk7wlhieFH2k0%2BKpsOb6/V/DyLkJRNhcymTjsTry1s%3D' (2026-05-10)
• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/0f7e2bea4088227a80502557f6c0e3b74949d6b5?narHash=sha256-A7GcOXjfo2xmZ3ERgN0j6GcqaVzqIf5zpYQcdfDaMr0%3D' (2026-04-26)
  → 'github:xddxdd/nix-cachyos-kernel/f2004296fc7cf75fccfa1028a6253dd5f42456a8?narHash=sha256-Nmacd0dSaHA6L35fTa6aXXoQUhoFa7%2BZ1k13Y9G3DPY%3D' (2026-05-14)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/1c61dfd1c3ad7762faa0db8b06c6af6c59cc4340?narHash=sha256-j8AobLjMzeKJugseObrVC4O5k7/aZCWoft2sCS3jWYs%3D' (2026-04-22)
  → 'github:CachyOS/linux-cachyos/6544eeb1694d6790292156dc300f149d14bc5210?narHash=sha256-LwRT4Wn48IPn674TMnrckayCioF0iMGYqE7bi/256/k%3D' (2026-05-13)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/46476ae2538db486462aef8a9de37d19030cdaf2?narHash=sha256-PIZCIf6xUTOUqLFbEGH0mSwu2O/YfeAmYlgdAbP4dhs%3D' (2026-04-24)
  → 'github:CachyOS/kernel-patches/ba7b8b92f1906de3742dadcbe2d032b5275da891?narHash=sha256-dNaGAK1lcop%2ByLsJzjlzSEF2YqBQYvIAKMxhaSqtxB0%3D' (2026-05-13)
• Updated input 'cachyos-kernel/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'cachyos-kernel/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a?narHash=sha256-%2BU7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ%3D' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/facea5e538604efa4893c08770fe9fca5bf62c2f?narHash=sha256-RJlLGrl%2BxHndIVK1NbPkIsItePNB3X4PIe8UTk3AHnw%3D' (2026-04-26)
  → 'github:NixOS/nixpkgs/39ea44cddd5060b8cd413ed5e13c6af61f302283?narHash=sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg%3D' (2026-05-14)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/c1cbd0994f5a3585dded85069f2c9103c54f5285?narHash=sha256-2zuDs9Lju99dg8MsSPf1frKPPgCRakDn%2BCEGX71cHJ0%3D' (2026-05-01)
  → 'github:AvengeMedia/DankMaterialShell/fbcc28785a2f42b17becf1d208d982cf218ede76?narHash=sha256-seaIGkMReVnJawQ3PZjzbKmQzuoIipQui%2BBe8bLUKes%3D' (2026-05-15)
• Removed input 'dank-material-shell/quickshell'
• Removed input 'dank-material-shell/quickshell/nixpkgs'
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/b7856c76e5d8733a4c6ffe2e453e2bcb1ab3b351?narHash=sha256-Jcxsfaebu%2BRzO4igAi1xDg3%2BXVJgm2%2BmsUF0P8PlmQg%3D' (2026-05-02)
  → 'github:AvengeMedia/dms-plugin-registry/fde8456bb08af0715041451592c461af66709b70?narHash=sha256-1uKZUme0C7vo3KSwlttK4l/0OWB/ktabKAD7kRHR5dE%3D' (2026-05-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0d02ec1d0a05f88ef9e74b516842900c41f0f2fe?narHash=sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo%3D' (2026-04-05)
  → 'github:nix-community/home-manager/d1686dc7d36cbd1234cb226ad6ef97e882716acb?narHash=sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8%3D' (2026-05-16)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/9cb587ade2aa1b4a7257f0238d41072690b0ca4f?narHash=sha256-egYNbRrkn%2B6SwTHinhdb6WUfzzdC3nXfCRqS321VylY%3D' (2026-05-01)
  → 'github:nix-community/home-manager/32b42d71b4b22c4465963285bb6e462d7c93d45e?narHash=sha256-jgIbBcGgKTtkp%2BlBas29hNFUU1t5O/2%2BGFvUjbiG0vM%3D' (2026-05-16)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/c065e951d631a3aa3736b45f17b3556597f63c1a?narHash=sha256-Q1fYHq1Gn79sQAkUDALR6dEC6l2WLkFyaB0cZLZnMQM%3D' (2026-05-01)
  → 'github:hyprwm/Hyprland/d56a9444c3a22dcf4981fd8f54508a098bac3971?narHash=sha256-f/f0/RQ4aT2eeaiiydK/gZP5o1YWd2YrrJu0g/xQ7bk%3D' (2026-05-16)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/648a13d0ee1e03a843b3e145b8ece15393058701?narHash=sha256-Ubqb/agkuMJK%2Bk19gjQgHux/eOYRc1sRGoOZOho8%2BVY%3D' (2026-04-22)
  → 'github:hyprwm/aquamarine/be35f75ac305f430f5f9d89b5f5a4af59ca7567e?narHash=sha256-Gu7UhWjwKCgSiVC3Qz/Rc7cYi9DNuDTBxYzg3kfLvfM%3D' (2026-05-12)
• Updated input 'hyprland/hyprlang':
    'github:hyprwm/hyprlang/7833ff33b2e82d3406337b5dcf0d1cec595d83e9?narHash=sha256-rl7i4aY%2B9p8LysJp7o8uRWahCkpFznCgGHXszlTw7b0%3D' (2026-04-17)
  → 'github:hyprwm/hyprlang/090117506ddc3d7f26e650ff344d378c2ec329cc?narHash=sha256-Qu%2BWf2Bp5qUjyn2YpZNq8a7JyzTGowhT1knrwE38a9U%3D' (2026-04-27)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/ec5c0c709706bad5b82f667fd8758eae442577ce?narHash=sha256-PwuoEJQcjSKJNP5T55qhfDwIP0tw5zxEhfu8GDfKfeg%3D' (2026-04-29)
  → 'github:hyprwm/hyprutils/a2dbd8a4cc51f7cbe4224732668392bb1aa79df2?narHash=sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE%3D' (2026-05-08)
• Updated input 'hyprland/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/fec9cf1abcc1011e46f0a0986f46bf93c6bf8b92?narHash=sha256-Uv0WZLhu89SafuSOmYDA7akrPt4wBRmsa1ucasO5aXg%3D' (2026-04-25)
  → 'github:hyprwm/hyprwayland-scanner/b8632713a6beaf28b56f2a7b0ab2fb7088dbb404?narHash=sha256-Jxixw6wZphUp%2BnHYxOKUYSckL17QMBx2d5Zp0rJHr1g%3D' (2026-04-25)
• Updated input 'hyprland/hyprwire':
    'github:hyprwm/hyprwire/f3a80888783702a39691b684d099e16b83ed4702?narHash=sha256-z9eGphrArEBpl1O/GCH0wlY6z4K9vA6yWh2gAS6qytU%3D' (2026-04-20)
  → 'github:hyprwm/hyprwire/85148a8e612808cf5ddb25d0b3c5840f3498a7dc?narHash=sha256-o6RzFj4nJXaPRY7EM01siuCQeT41RfwwmcmFQqwFJJg%3D' (2026-05-10)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
  → 'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/ecfcdcc781f48821d83e1e2a0e30d7beca0eeb5e?narHash=sha256-m1TNuBoSXUBSKhD9UVMkU90M0wFTPTfvIOOltO8IM8A%3D' (2026-04-24)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/813ea5ca9a1702a9a2d1f5836bc00172ef698968?narHash=sha256-8jlPtGSsv/CQY6tVVyLF4Jjd0gnS%2BZbn9yk/V13A9nM%3D' (2026-05-08)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/473804b3594dd829295484f1f479a560b8114f2d?narHash=sha256-iTtzJsp4hXp7/Y%2B2kVaosPPNBeUJbFiqQcZVRUtC%2BdM%3D' (2026-04-28)
  → 'github:hyprwm/hyprland-plugins/f1569efa6a939fd68cee605d2a34d0db3af5d879?narHash=sha256-IX6e5ggQi60UChhDJx6wsczbPRCEE8WZbEtlDMazLmU%3D' (2026-05-16)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=2fab248459e27558f5fcf018603a18f64ae41f81' (2026-05-13)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=4136a4c78342215ec3754da4fdddb90b8cd8ae86' (2026-05-16)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/38191826cb1e5fb9051a7e141fefe4941a2b4bed?narHash=sha256-9NyDMVf8ydUZGTzcPcLMQf0o1B3bte/00UGbuXHNWh8%3D' (2026-05-10)
  → 'github:YaLTeR/niri/cd5ac3e5e04bb5a11276d3c755fa25242818e05f?narHash=sha256-9VvAHNoi2wd0fxLfJOPChZMS7l6rhCtAJmpd59Hv5rw%3D' (2026-05-15)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/9a1c5aeb3d0a96aa11f02c33fdba319ddb339aad?narHash=sha256-pCdYLPCoZFUjTIOTto86MpJse/I0A8XHy3HIU53s/qM%3D' (2026-04-30)
  → 'github:fufexan/nix-gaming/2c555b88e541fb9da71d3c01f97d31ef1805d639?narHash=sha256-g8%2BlQJL7OjgD1T%2Bk6GzFC6LfHWc2gS0FFiO%2BMEIjZ9U%3D' (2026-05-14)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/0678d8986be1661af6bb555f3489f2fdfc31f6ff?narHash=sha256-qIoWPDs%2B0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ%3D' (2026-05-05)
• Updated input 'nix-gaming/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a?narHash=sha256-%2BU7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ%3D' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30?narHash=sha256-GMSVw35Q%2B294GlrTUKlx087E31z7KurReQ1YHSKp5iw%3D' (2026-04-23)
  → 'github:NixOS/nixpkgs/b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7?narHash=sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM%3D' (2026-05-08)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa?narHash=sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8%3D' (2026-04-26)
  → 'github:nix-community/nix-index-database/01466c414c7357ae2ce32be4a272a7c69e94ab5f?narHash=sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc%3D' (2026-05-10)
• Updated input 'nixpak':
    'github:nixpak/nixpak/b2bb4ab9d8e2457eeec3caa279b394525fbbe1a7?narHash=sha256-5Pqwqf4lEsZLZUcpefwMeq69d8hdirE83C5oWshBXo8%3D' (2026-04-16)
  → 'github:nixpak/nixpak/3ac3a6bbea994ebf5cc024d6288976a87c3986c1?narHash=sha256-7OCvTVOEEYlWwbHK%2B3%2B5pT3az07Dt4juYO4wdxiPGj4%3D' (2026-05-14)
• Updated input 'nixpak/flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'nixpak/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/554f6ed448ca74c00aa2371cde901ae1e73005b9?narHash=sha256-neu7ixXHjV3LobVjOndkL97u%2B6UF6Yoh%2BCUnzX7kUBQ%3D' (2026-03-15)
  → 'github:hercules-ci/hercules-ci-effects/e2456ee419f9d75f8382e3d6c5af4690b316a5a8?narHash=sha256-wA%2BONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI%3D' (2026-04-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
  → 'github:NixOS/nixpkgs/d7a713c0b7e47c908258e71cba7a2d77cc8d71d5?narHash=sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI%3D' (2026-05-14)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D' (2026-04-30)
  → 'github:NixOS/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32?narHash=sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA%3D' (2026-05-10)
• Updated input 'nur':
    'github:nix-community/NUR/6c0ac8b038dfaa434555c0bee45b0d03847b35a9?narHash=sha256-fH4uiqXKHdOk%2B52pK36LGXtwFSVl9i1bmlr6vufR69c%3D' (2026-05-02)
  → 'github:nix-community/NUR/65c51877443a1b3d63daabe7a696e6601df89caa?narHash=sha256-Ip1aeJq%2Bv5B/UZCumsDP/uRadZkL/znNdiK3UNayYBQ%3D' (2026-05-16)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=8db8ca1fecfcce8def1f9265fa1742baa0e0c271' (2026-05-02)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=7d1c9a9c6721606b129829134d6f614f015621e2' (2026-05-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8eaee5c45428b28b8c47a83e4c09dccec5f279b5?narHash=sha256-bc%2BZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E%3D' (2026-04-28)
  → 'github:Mic92/sops-nix/c591bf665727040c6cc5cb409079acb22dcce33c?narHash=sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8%3D' (2026-05-05)
• Updated input 'tmux-dotbar':
    'github:vaaleyard/tmux-dotbar/24a2e967e93ed7fd3688163436a2c0e4b2facc9a?narHash=sha256-WaRKepmPqiE%2BW8Tm0dBc6hGiqqZP122eXjrG0rJnt0w%3D' (2026-02-23)
  → 'github:vaaleyard/tmux-dotbar/f7dd0ff2b1302cbb59b826f0064a6aeb21f019eb?narHash=sha256-CAKEN8Sk3t0nonV2R9df/DFTTUrVnbso0ZVGgeeGINM%3D' (2026-05-11)```