### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778620495,
-        "narHash": "sha256-Gu7UhWjwKCgSiVC3Qz/Rc7cYi9DNuDTBxYzg3kfLvfM=",
+        "lastModified": 1778857089,
+        "narHash": "sha256-TclWRW2SdFeETLaiTG4BA8C8C4m/LppQEldncqyTzAQ=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "be35f75ac305f430f5f9d89b5f5a4af59ca7567e",
+        "rev": "ab2b0af63fbc9fb779d684f19149b790978be8a8",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778786644,
-        "narHash": "sha256-Nmacd0dSaHA6L35fTa6aXXoQUhoFa7+Z1k13Y9G3DPY=",
+        "lastModified": 1779477384,
+        "narHash": "sha256-lByanSWg/pKyDJ2pMuphIxMuCMy7qpYG2/gGjp//UFk=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "f2004296fc7cf75fccfa1028a6253dd5f42456a8",
+        "rev": "86d7051a5694db99f4db6165bcaf15e7bba8672a",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1778649239,
-        "narHash": "sha256-dNaGAK1lcop+yLsJzjlzSEF2YqBQYvIAKMxhaSqtxB0=",
+        "lastModified": 1779191960,
+        "narHash": "sha256-QqEC7SVMVf1vj9OoflWzP+nGewMrUNSBSf1dB8sUbqY=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "ba7b8b92f1906de3742dadcbe2d032b5275da891",
+        "rev": "65cbbfc17bb7e172cb06ef69037be5b0d517b2cd",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1778649404,
-        "narHash": "sha256-LwRT4Wn48IPn674TMnrckayCioF0iMGYqE7bi/256/k=",
+        "lastModified": 1779085181,
+        "narHash": "sha256-ZdiBlGOkI9tS3ggyNlJ5gU4qCkvGWLT3sbrnHEemN2o=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "6544eeb1694d6790292156dc300f149d14bc5210",
+        "rev": "391e1e35d62d30dccd14ec3af01d58e5310b7d80",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778852883,
-        "narHash": "sha256-seaIGkMReVnJawQ3PZjzbKmQzuoIipQui+Be8bLUKes=",
+        "lastModified": 1779455141,
+        "narHash": "sha256-e3u0LZbs9M4S+h6Qj/yj2Z0HJLqesjcO63lnJyNHB0Q=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "fbcc28785a2f42b17becf1d208d982cf218ede76",
+        "rev": "0b55fbcb152b80ed41ac0486e896a3b9f2c85659",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1779226674,
+        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778751506,
-        "narHash": "sha256-1uKZUme0C7vo3KSwlttK4l/0OWB/ktabKAD7kRHR5dE=",
+        "lastModified": 1779417178,
+        "narHash": "sha256-sqRVIGOTo9Mf2vFD2LzlsMa3zv0ltHsj18X6Rqe/4vY=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "fde8456bb08af0715041451592c461af66709b70",
+        "rev": "f1e59487f8c2109f397fdebeaa085c8521540c36",
         "type": "github"
       },
       "original": {
@@ -435,11 +435,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -776,11 +776,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776603440,
-        "narHash": "sha256-wA+ONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI=",
+        "lastModified": 1778930899,
+        "narHash": "sha256-OOEWyt8ma7QAysDbiP65J7li7KIdtZfnbA11gFnwyEI=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "e2456ee419f9d75f8382e3d6c5af4690b316a5a8",
+        "rev": "af4331c44f13977b6964745454eadcfee2d244d1",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778905220,
-        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
+        "lastModified": 1779506708,
+        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
+        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
         "type": "github"
       },
       "original": {
@@ -817,11 +817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778921576,
-        "narHash": "sha256-jgIbBcGgKTtkp+lBas29hNFUU1t5O/2+GFvUjbiG0vM=",
+        "lastModified": 1779507042,
+        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32b42d71b4b22c4465963285bb6e462d7c93d45e",
+        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
         "type": "github"
       },
       "original": {
@@ -952,11 +952,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778931952,
-        "narHash": "sha256-f/f0/RQ4aT2eeaiiydK/gZP5o1YWd2YrrJu0g/xQ7bk=",
+        "lastModified": 1779538437,
+        "narHash": "sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc+hBXUmZjQJOYs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d56a9444c3a22dcf4981fd8f54508a098bac3971",
+        "rev": "55b404b0a13518da3252cb176cf4a5a6ce9df2be",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778926589,
-        "narHash": "sha256-IX6e5ggQi60UChhDJx6wsczbPRCEE8WZbEtlDMazLmU=",
+        "lastModified": 1779209205,
+        "narHash": "sha256-asc7NpeB8vD66gvZeYcQkaWOs2X6Jgd29vBtP17vjxo=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "f1569efa6a939fd68cee605d2a34d0db3af5d879",
+        "rev": "1cb37fad68dff5f5840010c314fed5809b4ee66f",
         "type": "github"
       },
       "original": {
@@ -1158,11 +1158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778234770,
-        "narHash": "sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE=",
+        "lastModified": 1779475241,
+        "narHash": "sha256-Nw4DN0A5krWNcPBvuWe5Gz2yuxsUUPiDgtu6SVPJQeU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "a2dbd8a4cc51f7cbe4224732668392bb1aa79df2",
+        "rev": "3cd3972b2ee658a14d2610d8494e09259e530124",
         "type": "github"
       },
       "original": {
@@ -1477,11 +1477,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1778890551,
-        "narHash": "sha256-963lknoQiISHEQc4IcmGpln7dkOzurhmv8XeHxVo2fI=",
+        "lastModified": 1779495668,
+        "narHash": "sha256-ObRfCVogLtCMcPptyRfpKBtX4zrrOES5mj8i7u/Nx2Y=",
         "ref": "refs/heads/main",
-        "rev": "4136a4c78342215ec3754da4fdddb90b8cd8ae86",
-        "revCount": 115,
+        "rev": "319778283fde0abc0fc0b64d876239b0c5b5d3db",
+        "revCount": 118,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1514,11 +1514,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1778858756,
-        "narHash": "sha256-9VvAHNoi2wd0fxLfJOPChZMS7l6rhCtAJmpd59Hv5rw=",
+        "lastModified": 1779374863,
+        "narHash": "sha256-qKWgJ2MUODpg+b8tOwWMdMKREvs8TdGBz63SHaQZCeA=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "cd5ac3e5e04bb5a11276d3c755fa25242818e05f",
+        "rev": "4294948cf1c70c50e938383c2c865d7ca455ac7e",
         "type": "github"
       },
       "original": {
@@ -1550,11 +1550,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1778730790,
-        "narHash": "sha256-g8+lQJL7OjgD1T+k6GzFC6LfHWc2gS0FFiO+MEIjZ9U=",
+        "lastModified": 1779507984,
+        "narHash": "sha256-Fyege4MHeyrof0dlnScWjsxQl9JBeck4svJjggTXOjU=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "2c555b88e541fb9da71d3c01f97d31ef1805d639",
+        "rev": "3b36ed6ed66168c752ad0eba1274937b8a7e3c40",
         "type": "github"
       },
       "original": {
@@ -1570,11 +1570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -1613,11 +1613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778725521,
-        "narHash": "sha256-7OCvTVOEEYlWwbHK+3+5pT3az07Dt4juYO4wdxiPGj4=",
+        "lastModified": 1779329967,
+        "narHash": "sha256-mUMDkCo1T4GeOjQJlAh7/HSrll94y8IWXTCfEuV3GUQ=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "3ac3a6bbea994ebf5cc024d6288976a87c3986c1",
+        "rev": "b64e70327f7092537fca701c8115792b6088b5a1",
         "type": "github"
       },
       "original": {
@@ -1628,11 +1628,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778729098,
-        "narHash": "sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg=",
+        "lastModified": 1779436535,
+        "narHash": "sha256-jJ8YPw+bnLy1c8oI0hO4NKvbCQOt9V1aSUzhpLPs3Cw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "39ea44cddd5060b8cd413ed5e13c6af61f302283",
+        "rev": "d04de155b837ea2ba199ec83851b9dbffe57af08",
         "type": "github"
       },
       "original": {
@@ -1720,11 +1720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
@@ -1864,11 +1864,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
@@ -1880,11 +1880,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -1896,11 +1896,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {
@@ -1918,11 +1918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778928309,
-        "narHash": "sha256-Ip1aeJq+v5B/UZCumsDP/uRadZkL/znNdiK3UNayYBQ=",
+        "lastModified": 1779533926,
+        "narHash": "sha256-+0s3p4NRawaQm9g7LgtmVSKfmzj9rWIWvDjdlBeAHZM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65c51877443a1b3d63daabe7a696e6601df89caa",
+        "rev": "255647b232bfb564ce3ba4d1a79055d8a0d76be0",
         "type": "github"
       },
       "original": {
@@ -2034,11 +2034,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778488696,
-        "narHash": "sha256-QSWgYuZUCNUJ/cxmaq83WkcT7lHQDDfsPVgH+96kIl0=",
+        "lastModified": 1779430452,
+        "narHash": "sha256-zTslhsxLqUlRTML506iougTGzyR38Fzhzn7t4KDEuuE=",
         "ref": "master",
-        "rev": "7d1c9a9c6721606b129829134d6f614f015621e2",
-        "revCount": 818,
+        "rev": "4b4fca3224ab977dc515ac0bb78d00b3dfa71e00",
+        "revCount": 819,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/f2004296fc7cf75fccfa1028a6253dd5f42456a8?narHash=sha256-Nmacd0dSaHA6L35fTa6aXXoQUhoFa7%2BZ1k13Y9G3DPY%3D' (2026-05-14)
  → 'github:xddxdd/nix-cachyos-kernel/86d7051a5694db99f4db6165bcaf15e7bba8672a?narHash=sha256-lByanSWg/pKyDJ2pMuphIxMuCMy7qpYG2/gGjp//UFk%3D' (2026-05-22)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/6544eeb1694d6790292156dc300f149d14bc5210?narHash=sha256-LwRT4Wn48IPn674TMnrckayCioF0iMGYqE7bi/256/k%3D' (2026-05-13)
  → 'github:CachyOS/linux-cachyos/391e1e35d62d30dccd14ec3af01d58e5310b7d80?narHash=sha256-ZdiBlGOkI9tS3ggyNlJ5gU4qCkvGWLT3sbrnHEemN2o%3D' (2026-05-18)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/ba7b8b92f1906de3742dadcbe2d032b5275da891?narHash=sha256-dNaGAK1lcop%2ByLsJzjlzSEF2YqBQYvIAKMxhaSqtxB0%3D' (2026-05-13)
  → 'github:CachyOS/kernel-patches/65cbbfc17bb7e172cb06ef69037be5b0d517b2cd?narHash=sha256-QqEC7SVMVf1vj9OoflWzP%2BnGewMrUNSBSf1dB8sUbqY%3D' (2026-05-19)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/39ea44cddd5060b8cd413ed5e13c6af61f302283?narHash=sha256-17SbusskVZng4nwevRqsWNJf27nMG7UczvtgWTUJttg%3D' (2026-05-14)
  → 'github:NixOS/nixpkgs/d04de155b837ea2ba199ec83851b9dbffe57af08?narHash=sha256-jJ8YPw%2BbnLy1c8oI0hO4NKvbCQOt9V1aSUzhpLPs3Cw%3D' (2026-05-22)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/fbcc28785a2f42b17becf1d208d982cf218ede76?narHash=sha256-seaIGkMReVnJawQ3PZjzbKmQzuoIipQui%2BBe8bLUKes%3D' (2026-05-15)
  → 'github:AvengeMedia/DankMaterialShell/0b55fbcb152b80ed41ac0486e896a3b9f2c85659?narHash=sha256-e3u0LZbs9M4S%2Bh6Qj/yj2Z0HJLqesjcO63lnJyNHB0Q%3D' (2026-05-22)
• Updated input 'disko':
    'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
  → 'github:nix-community/disko/65fb947964bd44fc0008faf77d1fcb7a9f40bb32?narHash=sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs%3D' (2026-05-19)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/fde8456bb08af0715041451592c461af66709b70?narHash=sha256-1uKZUme0C7vo3KSwlttK4l/0OWB/ktabKAD7kRHR5dE%3D' (2026-05-14)
  → 'github:AvengeMedia/dms-plugin-registry/f1e59487f8c2109f397fdebeaa085c8521540c36?narHash=sha256-sqRVIGOTo9Mf2vFD2LzlsMa3zv0ltHsj18X6Rqe/4vY%3D' (2026-05-22)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d1686dc7d36cbd1234cb226ad6ef97e882716acb?narHash=sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8%3D' (2026-05-16)
  → 'github:nix-community/home-manager/3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f?narHash=sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0%3D' (2026-05-23)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/32b42d71b4b22c4465963285bb6e462d7c93d45e?narHash=sha256-jgIbBcGgKTtkp%2BlBas29hNFUU1t5O/2%2BGFvUjbiG0vM%3D' (2026-05-16)
  → 'github:nix-community/home-manager/509ed3c603349a9d43de9e2ae6613baea6bd5b34?narHash=sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ%3D' (2026-05-23)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/d56a9444c3a22dcf4981fd8f54508a098bac3971?narHash=sha256-f/f0/RQ4aT2eeaiiydK/gZP5o1YWd2YrrJu0g/xQ7bk%3D' (2026-05-16)
  → 'github:hyprwm/Hyprland/55b404b0a13518da3252cb176cf4a5a6ce9df2be?narHash=sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc%2BhBXUmZjQJOYs%3D' (2026-05-23)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/be35f75ac305f430f5f9d89b5f5a4af59ca7567e?narHash=sha256-Gu7UhWjwKCgSiVC3Qz/Rc7cYi9DNuDTBxYzg3kfLvfM%3D' (2026-05-12)
  → 'github:hyprwm/aquamarine/ab2b0af63fbc9fb779d684f19149b790978be8a8?narHash=sha256-TclWRW2SdFeETLaiTG4BA8C8C4m/LppQEldncqyTzAQ%3D' (2026-05-15)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/a2dbd8a4cc51f7cbe4224732668392bb1aa79df2?narHash=sha256-jAcsogZwWMfXT9MfXxZzkwliAqIuZUV0p71h6Ba9ReE%3D' (2026-05-08)
  → 'github:hyprwm/hyprutils/3cd3972b2ee658a14d2610d8494e09259e530124?narHash=sha256-Nw4DN0A5krWNcPBvuWe5Gz2yuxsUUPiDgtu6SVPJQeU%3D' (2026-05-22)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/f1569efa6a939fd68cee605d2a34d0db3af5d879?narHash=sha256-IX6e5ggQi60UChhDJx6wsczbPRCEE8WZbEtlDMazLmU%3D' (2026-05-16)
  → 'github:hyprwm/hyprland-plugins/1cb37fad68dff5f5840010c314fed5809b4ee66f?narHash=sha256-asc7NpeB8vD66gvZeYcQkaWOs2X6Jgd29vBtP17vjxo%3D' (2026-05-19)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=4136a4c78342215ec3754da4fdddb90b8cd8ae86' (2026-05-16)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=319778283fde0abc0fc0b64d876239b0c5b5d3db' (2026-05-23)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/cd5ac3e5e04bb5a11276d3c755fa25242818e05f?narHash=sha256-9VvAHNoi2wd0fxLfJOPChZMS7l6rhCtAJmpd59Hv5rw%3D' (2026-05-15)
  → 'github:YaLTeR/niri/4294948cf1c70c50e938383c2c865d7ca455ac7e?narHash=sha256-qKWgJ2MUODpg%2Bb8tOwWMdMKREvs8TdGBz63SHaQZCeA%3D' (2026-05-21)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32?narHash=sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA%3D' (2026-05-10)
  → 'github:nixos/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1?narHash=sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic%3D' (2026-05-21)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/2c555b88e541fb9da71d3c01f97d31ef1805d639?narHash=sha256-g8%2BlQJL7OjgD1T%2Bk6GzFC6LfHWc2gS0FFiO%2BMEIjZ9U%3D' (2026-05-14)
  → 'github:fufexan/nix-gaming/3b36ed6ed66168c752ad0eba1274937b8a7e3c40?narHash=sha256-Fyege4MHeyrof0dlnScWjsxQl9JBeck4svJjggTXOjU%3D' (2026-05-23)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/0678d8986be1661af6bb555f3489f2fdfc31f6ff?narHash=sha256-qIoWPDs%2B0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ%3D' (2026-05-05)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'nix-gaming/git-hooks':
    'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
  → 'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7?narHash=sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM%3D' (2026-05-08)
  → 'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/01466c414c7357ae2ce32be4a272a7c69e94ab5f?narHash=sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc%3D' (2026-05-10)
  → 'github:nix-community/nix-index-database/f680e0d3c1dbefe298c423691662e238496890f2?narHash=sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg%3D' (2026-05-17)
• Updated input 'nixpak':
    'github:nixpak/nixpak/3ac3a6bbea994ebf5cc024d6288976a87c3986c1?narHash=sha256-7OCvTVOEEYlWwbHK%2B3%2B5pT3az07Dt4juYO4wdxiPGj4%3D' (2026-05-14)
  → 'github:nixpak/nixpak/b64e70327f7092537fca701c8115792b6088b5a1?narHash=sha256-mUMDkCo1T4GeOjQJlAh7/HSrll94y8IWXTCfEuV3GUQ%3D' (2026-05-21)
• Updated input 'nixpak/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/e2456ee419f9d75f8382e3d6c5af4690b316a5a8?narHash=sha256-wA%2BONiwbvQIy7ERJx/ruhV7y5xku6XKstXCII5bIbdI%3D' (2026-04-19)
  → 'github:hercules-ci/hercules-ci-effects/af4331c44f13977b6964745454eadcfee2d244d1?narHash=sha256-OOEWyt8ma7QAysDbiP65J7li7KIdtZfnbA11gFnwyEI%3D' (2026-05-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d7a713c0b7e47c908258e71cba7a2d77cc8d71d5?narHash=sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI%3D' (2026-05-14)
  → 'github:NixOS/nixpkgs/687f05a9184cad4eaf905c48b63649e3a86f5433?narHash=sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg%3D' (2026-05-18)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32?narHash=sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA%3D' (2026-05-10)
  → 'github:NixOS/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1?narHash=sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic%3D' (2026-05-21)
• Updated input 'nur':
    'github:nix-community/NUR/65c51877443a1b3d63daabe7a696e6601df89caa?narHash=sha256-Ip1aeJq%2Bv5B/UZCumsDP/uRadZkL/znNdiK3UNayYBQ%3D' (2026-05-16)
  → 'github:nix-community/NUR/255647b232bfb564ce3ba4d1a79055d8a0d76be0?narHash=sha256-%2B0s3p4NRawaQm9g7LgtmVSKfmzj9rWIWvDjdlBeAHZM%3D' (2026-05-23)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=7d1c9a9c6721606b129829134d6f614f015621e2' (2026-05-11)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4b4fca3224ab977dc515ac0bb78d00b3dfa71e00' (2026-05-22)```