### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778395619,
-        "narHash": "sha256-MIk7wlhieFH2k0+KpsOb6/V/DyLkJRNhcymTjsTry1s=",
+        "lastModified": 1779995374,
+        "narHash": "sha256-Nw9Gk5OC3gvB/sDB1PCyFrDgLzrKcDr7vooFnm5fJTw=",
         "owner": "saatvik333",
         "repo": "wayland-bongocat",
-        "rev": "e140ceab744aeb8f2c327f9eef82121c03491b87",
+        "rev": "2d4f1a28760acec7881bc90a217ac061bd97174e",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1779477384,
-        "narHash": "sha256-lByanSWg/pKyDJ2pMuphIxMuCMy7qpYG2/gGjp//UFk=",
+        "lastModified": 1780084541,
+        "narHash": "sha256-1dfrj9KRVjYdRQV677wHJVqSi1+IseAofINIIpPO+7E=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "86d7051a5694db99f4db6165bcaf15e7bba8672a",
+        "rev": "bc4719a00b3e52764b947cb3c7f15a8b8769432e",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1779191960,
-        "narHash": "sha256-QqEC7SVMVf1vj9OoflWzP+nGewMrUNSBSf1dB8sUbqY=",
+        "lastModified": 1779996637,
+        "narHash": "sha256-DcA59mHfCUfbr7EtH9YJUb3t62TcyXwC/I0QMyUs1bo=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "65cbbfc17bb7e172cb06ef69037be5b0d517b2cd",
+        "rev": "b87558b7c865628c48c1d6ff5c827b9df40e9281",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1779085181,
-        "narHash": "sha256-ZdiBlGOkI9tS3ggyNlJ5gU4qCkvGWLT3sbrnHEemN2o=",
+        "lastModified": 1779959490,
+        "narHash": "sha256-FS/SbuYuRt5biCp1ja0Se12V2q3Y3p+O+rAdFQvuJT4=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "391e1e35d62d30dccd14ec3af01d58e5310b7d80",
+        "rev": "1d38a1c83db0cddff4963516eb3f6838981cb6ae",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779455141,
-        "narHash": "sha256-e3u0LZbs9M4S+h6Qj/yj2Z0HJLqesjcO63lnJyNHB0Q=",
+        "lastModified": 1780120546,
+        "narHash": "sha256-47v6HJW/oBwwRjRw1Z1SfKyp87zsY1MAIQyivvi/yFU=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "0b55fbcb152b80ed41ac0486e896a3b9f2c85659",
+        "rev": "2b661e241d556e577b635778116d71414ab97af1",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779226674,
-        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
+        "lastModified": 1780048612,
+        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
+        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779417178,
-        "narHash": "sha256-sqRVIGOTo9Mf2vFD2LzlsMa3zv0ltHsj18X6Rqe/4vY=",
+        "lastModified": 1780107042,
+        "narHash": "sha256-ISqJC5Vpg3OA1zpfe6F3NKYrsByprO0UF0Y7r/j5Bvo=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "f1e59487f8c2109f397fdebeaa085c8521540c36",
+        "rev": "4b1a70c5423cb178bc80dbbba4ab8154ff7cbfd2",
         "type": "github"
       },
       "original": {
@@ -817,11 +817,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779507042,
-        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -952,11 +952,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779538437,
-        "narHash": "sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc+hBXUmZjQJOYs=",
+        "lastModified": 1780142732,
+        "narHash": "sha256-7sBe6ujnxspLeX7zMSKpGpOuOXGeUmvDV/78CSsY+PQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "55b404b0a13518da3252cb176cf4a5a6ce9df2be",
+        "rev": "34fddc949042e45d22bed6cbe72f9a9c838914fa",
         "type": "github"
       },
       "original": {
@@ -1477,11 +1477,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1779495668,
-        "narHash": "sha256-ObRfCVogLtCMcPptyRfpKBtX4zrrOES5mj8i7u/Nx2Y=",
+        "lastModified": 1780100188,
+        "narHash": "sha256-hymi6vwcrO6cohO8fcK+A3+kx4PkqmApYty/5BTa6Ec=",
         "ref": "refs/heads/main",
-        "rev": "319778283fde0abc0fc0b64d876239b0c5b5d3db",
-        "revCount": 118,
+        "rev": "5e683782020f3f23e51995235d71ab0b8152272a",
+        "revCount": 126,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1514,11 +1514,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1779374863,
-        "narHash": "sha256-qKWgJ2MUODpg+b8tOwWMdMKREvs8TdGBz63SHaQZCeA=",
+        "lastModified": 1780056110,
+        "narHash": "sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "4294948cf1c70c50e938383c2c865d7ca455ac7e",
+        "rev": "f9f43d826ab4014a7c302be28d7da33e12f5be37",
         "type": "github"
       },
       "original": {
@@ -1550,11 +1550,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1779507984,
-        "narHash": "sha256-Fyege4MHeyrof0dlnScWjsxQl9JBeck4svJjggTXOjU=",
+        "lastModified": 1779768228,
+        "narHash": "sha256-/dRavNAx/Mp67xcQQ3JBIMyf0cLoXqKedafB1+wksAE=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "3b36ed6ed66168c752ad0eba1274937b8a7e3c40",
+        "rev": "6e7a8414c0f547a86646eb0b56ebf89e7cc217a2",
         "type": "github"
       },
       "original": {
@@ -1570,11 +1570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778999127,
-        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
+        "lastModified": 1779604987,
+        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
+        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
         "type": "github"
       },
       "original": {
@@ -1613,11 +1613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779329967,
-        "narHash": "sha256-mUMDkCo1T4GeOjQJlAh7/HSrll94y8IWXTCfEuV3GUQ=",
+        "lastModified": 1779934815,
+        "narHash": "sha256-2DmT1UZMP0rr1Z3OSSYQhF2gZq2oNmUxqJwXifz7Utw=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "b64e70327f7092537fca701c8115792b6088b5a1",
+        "rev": "5bf20bb84d0b4c1870079625f65d166f00737aea",
         "type": "github"
       },
       "original": {
@@ -1628,11 +1628,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779436535,
-        "narHash": "sha256-jJ8YPw+bnLy1c8oI0hO4NKvbCQOt9V1aSUzhpLPs3Cw=",
+        "lastModified": 1780011192,
+        "narHash": "sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d04de155b837ea2ba199ec83851b9dbffe57af08",
+        "rev": "3242faf14b7611a62ce0f0071619438a08b65c12",
         "type": "github"
       },
       "original": {
@@ -1720,11 +1720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -1864,11 +1864,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -1880,11 +1880,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -1896,11 +1896,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -1918,11 +1918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779533926,
-        "narHash": "sha256-+0s3p4NRawaQm9g7LgtmVSKfmzj9rWIWvDjdlBeAHZM=",
+        "lastModified": 1780141321,
+        "narHash": "sha256-/3vb9T3rdMAQy3Vvcmy1XJ+Sh5Tb2SIppcHm/57TUgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "255647b232bfb564ce3ba4d1a79055d8a0d76be0",
+        "rev": "7f8c385f2da5211ddab1fccc3daf854431ea5452",
         "type": "github"
       },
       "original": {
@@ -2533,11 +2533,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1773622265,
-        "narHash": "sha256-wToKwH7IgWdGLMSIWksEDs4eumR6UbbsuPQ42r0oTXQ=",
+        "lastModified": 1779745227,
+        "narHash": "sha256-yqY7RtEJGJiENzR0GwL6q69tSAy6xAAmAcLuIhLjPf8=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "a879e5e0896a326adc79c474bf457b8b99011027",
+        "rev": "5d1efbc9dc3ab1c10160b656e0247f3325daf0f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'bongocat':
    'github:saatvik333/wayland-bongocat/e140ceab744aeb8f2c327f9eef82121c03491b87?narHash=sha256-MIk7wlhieFH2k0%2BKpsOb6/V/DyLkJRNhcymTjsTry1s%3D' (2026-05-10)
  → 'github:saatvik333/wayland-bongocat/2d4f1a28760acec7881bc90a217ac061bd97174e?narHash=sha256-Nw9Gk5OC3gvB/sDB1PCyFrDgLzrKcDr7vooFnm5fJTw%3D' (2026-05-28)
• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/86d7051a5694db99f4db6165bcaf15e7bba8672a?narHash=sha256-lByanSWg/pKyDJ2pMuphIxMuCMy7qpYG2/gGjp//UFk%3D' (2026-05-22)
  → 'github:xddxdd/nix-cachyos-kernel/bc4719a00b3e52764b947cb3c7f15a8b8769432e?narHash=sha256-1dfrj9KRVjYdRQV677wHJVqSi1%2BIseAofINIIpPO%2B7E%3D' (2026-05-29)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/391e1e35d62d30dccd14ec3af01d58e5310b7d80?narHash=sha256-ZdiBlGOkI9tS3ggyNlJ5gU4qCkvGWLT3sbrnHEemN2o%3D' (2026-05-18)
  → 'github:CachyOS/linux-cachyos/1d38a1c83db0cddff4963516eb3f6838981cb6ae?narHash=sha256-FS/SbuYuRt5biCp1ja0Se12V2q3Y3p%2BO%2BrAdFQvuJT4%3D' (2026-05-28)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/65cbbfc17bb7e172cb06ef69037be5b0d517b2cd?narHash=sha256-QqEC7SVMVf1vj9OoflWzP%2BnGewMrUNSBSf1dB8sUbqY%3D' (2026-05-19)
  → 'github:CachyOS/kernel-patches/b87558b7c865628c48c1d6ff5c827b9df40e9281?narHash=sha256-DcA59mHfCUfbr7EtH9YJUb3t62TcyXwC/I0QMyUs1bo%3D' (2026-05-28)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/d04de155b837ea2ba199ec83851b9dbffe57af08?narHash=sha256-jJ8YPw%2BbnLy1c8oI0hO4NKvbCQOt9V1aSUzhpLPs3Cw%3D' (2026-05-22)
  → 'github:NixOS/nixpkgs/3242faf14b7611a62ce0f0071619438a08b65c12?narHash=sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM%2Bk%3D' (2026-05-28)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/0b55fbcb152b80ed41ac0486e896a3b9f2c85659?narHash=sha256-e3u0LZbs9M4S%2Bh6Qj/yj2Z0HJLqesjcO63lnJyNHB0Q%3D' (2026-05-22)
  → 'github:AvengeMedia/DankMaterialShell/2b661e241d556e577b635778116d71414ab97af1?narHash=sha256-47v6HJW/oBwwRjRw1Z1SfKyp87zsY1MAIQyivvi/yFU%3D' (2026-05-30)
• Updated input 'disko':
    'github:nix-community/disko/65fb947964bd44fc0008faf77d1fcb7a9f40bb32?narHash=sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs%3D' (2026-05-19)
  → 'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/f1e59487f8c2109f397fdebeaa085c8521540c36?narHash=sha256-sqRVIGOTo9Mf2vFD2LzlsMa3zv0ltHsj18X6Rqe/4vY%3D' (2026-05-22)
  → 'github:AvengeMedia/dms-plugin-registry/4b1a70c5423cb178bc80dbbba4ab8154ff7cbfd2?narHash=sha256-ISqJC5Vpg3OA1zpfe6F3NKYrsByprO0UF0Y7r/j5Bvo%3D' (2026-05-30)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/509ed3c603349a9d43de9e2ae6613baea6bd5b34?narHash=sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ%3D' (2026-05-23)
  → 'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/55b404b0a13518da3252cb176cf4a5a6ce9df2be?narHash=sha256-QTVm1lfienmW8sjcdnqwpffgMG8QPc%2BhBXUmZjQJOYs%3D' (2026-05-23)
  → 'github:hyprwm/Hyprland/34fddc949042e45d22bed6cbe72f9a9c838914fa?narHash=sha256-7sBe6ujnxspLeX7zMSKpGpOuOXGeUmvDV/78CSsY%2BPQ%3D' (2026-05-30)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=319778283fde0abc0fc0b64d876239b0c5b5d3db' (2026-05-23)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=5e683782020f3f23e51995235d71ab0b8152272a' (2026-05-30)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/4294948cf1c70c50e938383c2c865d7ca455ac7e?narHash=sha256-qKWgJ2MUODpg%2Bb8tOwWMdMKREvs8TdGBz63SHaQZCeA%3D' (2026-05-21)
  → 'github:YaLTeR/niri/f9f43d826ab4014a7c302be28d7da33e12f5be37?narHash=sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU%3D' (2026-05-29)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1?narHash=sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic%3D' (2026-05-21)
  → 'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
• Updated input 'niri-nix/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/a879e5e0896a326adc79c474bf457b8b99011027?narHash=sha256-wToKwH7IgWdGLMSIWksEDs4eumR6UbbsuPQ42r0oTXQ%3D' (2026-03-16)
  → 'github:Supreeeme/xwayland-satellite/5d1efbc9dc3ab1c10160b656e0247f3325daf0f2?narHash=sha256-yqY7RtEJGJiENzR0GwL6q69tSAy6xAAmAcLuIhLjPf8%3D' (2026-05-25)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/3b36ed6ed66168c752ad0eba1274937b8a7e3c40?narHash=sha256-Fyege4MHeyrof0dlnScWjsxQl9JBeck4svJjggTXOjU%3D' (2026-05-23)
  → 'github:fufexan/nix-gaming/6e7a8414c0f547a86646eb0b56ebf89e7cc217a2?narHash=sha256-/dRavNAx/Mp67xcQQ3JBIMyf0cLoXqKedafB1%2BwksAE%3D' (2026-05-26)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
  → 'github:NixOS/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456?narHash=sha256-q%2BfF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8%3D' (2026-05-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f680e0d3c1dbefe298c423691662e238496890f2?narHash=sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg%3D' (2026-05-17)
  → 'github:nix-community/nix-index-database/8fba98c80b48fa013820e0163c5096922fea4ddd?narHash=sha256-ZQ5z%2BfVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs%2Bs%3D' (2026-05-24)
• Updated input 'nixpak':
    'github:nixpak/nixpak/b64e70327f7092537fca701c8115792b6088b5a1?narHash=sha256-mUMDkCo1T4GeOjQJlAh7/HSrll94y8IWXTCfEuV3GUQ%3D' (2026-05-21)
  → 'github:nixpak/nixpak/5bf20bb84d0b4c1870079625f65d166f00737aea?narHash=sha256-2DmT1UZMP0rr1Z3OSSYQhF2gZq2oNmUxqJwXifz7Utw%3D' (2026-05-28)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/687f05a9184cad4eaf905c48b63649e3a86f5433?narHash=sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg%3D' (2026-05-18)
  → 'github:NixOS/nixpkgs/25f538306313eae3927264466c70d7001dcea1df?narHash=sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY%3D' (2026-05-26)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1?narHash=sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic%3D' (2026-05-21)
  → 'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
• Updated input 'nur':
    'github:nix-community/NUR/255647b232bfb564ce3ba4d1a79055d8a0d76be0?narHash=sha256-%2B0s3p4NRawaQm9g7LgtmVSKfmzj9rWIWvDjdlBeAHZM%3D' (2026-05-23)
  → 'github:nix-community/NUR/7f8c385f2da5211ddab1fccc3daf854431ea5452?narHash=sha256-/3vb9T3rdMAQy3Vvcmy1XJ%2BSh5Tb2SIppcHm/57TUgI%3D' (2026-05-30)```