### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780084541,
-        "narHash": "sha256-1dfrj9KRVjYdRQV677wHJVqSi1+IseAofINIIpPO+7E=",
+        "lastModified": 1780253365,
+        "narHash": "sha256-wcJ+6+Z+mfzBjClI0XsjOoGSW6o1RldVj6UETLzK+GQ=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "bc4719a00b3e52764b947cb3c7f15a8b8769432e",
+        "rev": "236462fb93cb56e26e6a6801ba5edb6dad66be0d",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780380182,
-        "narHash": "sha256-cukhSecNvADnLa7dk7GeUB/e1vM6hvRAFt0IDZ8Ox3I=",
+        "lastModified": 1780715834,
+        "narHash": "sha256-DJwIs0RG20sjWR37mF4I7k3P3SQM97BDh9o8V5cUgo8=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "335c5b4ac55382c2077ab2a18129c03dafb9558b",
+        "rev": "e7ccb702a3141bfb62a6597e7863c25afff07d60",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780048612,
-        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
+        "lastModified": 1780290312,
+        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
+        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
         "type": "github"
       },
       "original": {
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780396806,
-        "narHash": "sha256-jYJd4QEaQFy3gWQE7eQp/vrHWFqFU9hZm13dJ6JUSVE=",
+        "lastModified": 1780711975,
+        "narHash": "sha256-l6oEu3L8ptc6jc6QHDyK6uMLjgSky0UjtDi6acEocDk=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "ea67af13d6a36e2368f48b0c3d3f54baf7e4cd24",
+        "rev": "3483bc43c345f4c6c8ddd68974aa3b571da922d7",
         "type": "github"
       },
       "original": {
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -929,11 +929,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1780142732,
-        "narHash": "sha256-7sBe6ujnxspLeX7zMSKpGpOuOXGeUmvDV/78CSsY+PQ=",
+        "lastModified": 1780694402,
+        "narHash": "sha256-gAnq7tsOsLnu/rR0tKxI5pMCjMps5CYaHU6rUdXHXyE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "34fddc949042e45d22bed6cbe72f9a9c838914fa",
+        "rev": "fcbbd6d4d80033c40e3b702518e1a2ba3f479452",
         "type": "github"
       },
       "original": {
@@ -1454,11 +1454,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780100188,
-        "narHash": "sha256-hymi6vwcrO6cohO8fcK+A3+kx4PkqmApYty/5BTa6Ec=",
+        "lastModified": 1780647854,
+        "narHash": "sha256-UihHR5aXPButsiQUvvnmvKxZWkRe+52nrVLd9BztXrE=",
         "ref": "refs/heads/main",
-        "rev": "5e683782020f3f23e51995235d71ab0b8152272a",
-        "revCount": 126,
+        "rev": "4aaba8693d0fe8cb785f6b0b4497eb63cb2cf590",
+        "revCount": 130,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1514,11 +1514,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1779656157,
-        "narHash": "sha256-dA6u30HIKBACOYuzQHHaBIDBFnic4iaNh+nHEj2OLwg=",
+        "lastModified": 1780102376,
+        "narHash": "sha256-/AY1hlAixYPPuT38ldUkYzKBp7oP3tA45+7MBK+23JI=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "e818de97b42cd0384efda2d6d257ae2f54bcb259",
+        "rev": "dfd985404c9632f57a0cc16654c270a772839351",
         "type": "github"
       },
       "original": {
@@ -1550,11 +1550,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1779768228,
-        "narHash": "sha256-/dRavNAx/Mp67xcQQ3JBIMyf0cLoXqKedafB1+wksAE=",
+        "lastModified": 1780633087,
+        "narHash": "sha256-l800yeumkT92AlTl7trOEeh2Of6Lx2nU6l55uWt0kxk=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "6e7a8414c0f547a86646eb0b56ebf89e7cc217a2",
+        "rev": "b7ca7b683fded9623dc5f2e7f1a8d111c4a5d215",
         "type": "github"
       },
       "original": {
@@ -1570,11 +1570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779604987,
-        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
+        "lastModified": 1780210899,
+        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
+        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
         "type": "github"
       },
       "original": {
@@ -1613,11 +1613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779934815,
-        "narHash": "sha256-2DmT1UZMP0rr1Z3OSSYQhF2gZq2oNmUxqJwXifz7Utw=",
+        "lastModified": 1780539866,
+        "narHash": "sha256-SLjFDX7AOX+vstHIpGztj1JrJ5J96SxfN8kPa0ZfMVY=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "5bf20bb84d0b4c1870079625f65d166f00737aea",
+        "rev": "ad5ac7d24a505db29671edadfe6a8f985aa6e94e",
         "type": "github"
       },
       "original": {
@@ -1628,11 +1628,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780011192,
-        "narHash": "sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM+k=",
+        "lastModified": 1780206209,
+        "narHash": "sha256-33WNQ5sssy+8+xhUz953aEnjR1Oh828j0DgLU1TfMqE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3242faf14b7611a62ce0f0071619438a08b65c12",
+        "rev": "45cf63e030188dd38532669b2450182bfc2d4653",
         "type": "github"
       },
       "original": {
@@ -1720,11 +1720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1736,11 +1736,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
@@ -1896,32 +1896,32 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1934,11 +1934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780141321,
-        "narHash": "sha256-/3vb9T3rdMAQy3Vvcmy1XJ+Sh5Tb2SIppcHm/57TUgI=",
+        "lastModified": 1780748195,
+        "narHash": "sha256-UgIAGTmhoLKIuKvijQtGOpjD3uQbUiBEK8aZSDYe80A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f8c385f2da5211ddab1fccc3daf854431ea5452",
+        "rev": "68708dd94f396de9e791b2779979684c9ba36550",
         "type": "github"
       },
       "original": {
@@ -2050,11 +2050,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779430452,
-        "narHash": "sha256-zTslhsxLqUlRTML506iougTGzyR38Fzhzn7t4KDEuuE=",
+        "lastModified": 1780303737,
+        "narHash": "sha256-7HgdJBG4BgAPDyHKKxWtxj7nziqsQo6zQCXtwy+L9fs=",
         "ref": "master",
-        "rev": "4b4fca3224ab977dc515ac0bb78d00b3dfa71e00",
-        "revCount": 819,
+        "rev": "b66495fcc5022681b56b61f928c7acbe910e722c",
+        "revCount": 821,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -2191,11 +2191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/bc4719a00b3e52764b947cb3c7f15a8b8769432e?narHash=sha256-1dfrj9KRVjYdRQV677wHJVqSi1%2BIseAofINIIpPO%2B7E%3D' (2026-05-29)
  → 'github:xddxdd/nix-cachyos-kernel/236462fb93cb56e26e6a6801ba5edb6dad66be0d?narHash=sha256-wcJ%2B6%2BZ%2BmfzBjClI0XsjOoGSW6o1RldVj6UETLzK%2BGQ%3D' (2026-05-31)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/3242faf14b7611a62ce0f0071619438a08b65c12?narHash=sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM%2Bk%3D' (2026-05-28)
  → 'github:NixOS/nixpkgs/45cf63e030188dd38532669b2450182bfc2d4653?narHash=sha256-33WNQ5sssy%2B8%2BxhUz953aEnjR1Oh828j0DgLU1TfMqE%3D' (2026-05-31)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/335c5b4ac55382c2077ab2a18129c03dafb9558b?narHash=sha256-cukhSecNvADnLa7dk7GeUB/e1vM6hvRAFt0IDZ8Ox3I%3D' (2026-06-02)
  → 'github:AvengeMedia/DankMaterialShell/e7ccb702a3141bfb62a6597e7863c25afff07d60?narHash=sha256-DJwIs0RG20sjWR37mF4I7k3P3SQM97BDh9o8V5cUgo8%3D' (2026-06-06)
• Updated input 'disko':
    'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
  → 'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe?narHash=sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo%3D' (2026-06-01)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/ea67af13d6a36e2368f48b0c3d3f54baf7e4cd24?narHash=sha256-jYJd4QEaQFy3gWQE7eQp/vrHWFqFU9hZm13dJ6JUSVE%3D' (2026-06-02)
  → 'github:AvengeMedia/dms-plugin-registry/3483bc43c345f4c6c8ddd68974aa3b571da922d7?narHash=sha256-l6oEu3L8ptc6jc6QHDyK6uMLjgSky0UjtDi6acEocDk%3D' (2026-06-06)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
  → 'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16?narHash=sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8%3D' (2026-06-05)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/34fddc949042e45d22bed6cbe72f9a9c838914fa?narHash=sha256-7sBe6ujnxspLeX7zMSKpGpOuOXGeUmvDV/78CSsY%2BPQ%3D' (2026-05-30)
  → 'github:hyprwm/Hyprland/fcbbd6d4d80033c40e3b702518e1a2ba3f479452?narHash=sha256-gAnq7tsOsLnu/rR0tKxI5pMCjMps5CYaHU6rUdXHXyE%3D' (2026-06-05)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=5e683782020f3f23e51995235d71ab0b8152272a' (2026-05-30)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=4aaba8693d0fe8cb785f6b0b4497eb63cb2cf590' (2026-06-05)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/e818de97b42cd0384efda2d6d257ae2f54bcb259?narHash=sha256-dA6u30HIKBACOYuzQHHaBIDBFnic4iaNh%2BnHEj2OLwg%3D' (2026-05-24)
  → 'github:LovingMelody/nix-citizen/dfd985404c9632f57a0cc16654c270a772839351?narHash=sha256-/AY1hlAixYPPuT38ldUkYzKBp7oP3tA45%2B7MBK%2B23JI%3D' (2026-05-30)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456?narHash=sha256-q%2BfF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8%3D' (2026-05-23)
  → 'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/6e7a8414c0f547a86646eb0b56ebf89e7cc217a2?narHash=sha256-/dRavNAx/Mp67xcQQ3JBIMyf0cLoXqKedafB1%2BwksAE%3D' (2026-05-26)
  → 'github:fufexan/nix-gaming/b7ca7b683fded9623dc5f2e7f1a8d111c4a5d215?narHash=sha256-l800yeumkT92AlTl7trOEeh2Of6Lx2nU6l55uWt0kxk%3D' (2026-06-05)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/25f538306313eae3927264466c70d7001dcea1df?narHash=sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY%3D' (2026-05-26)
  → 'github:NixOS/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b?narHash=sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL%2BWNQD0rJfJZQ%3D' (2026-05-29)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/8fba98c80b48fa013820e0163c5096922fea4ddd?narHash=sha256-ZQ5z%2BfVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs%2Bs%3D' (2026-05-24)
  → 'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e?narHash=sha256-4axz3OBPTKa6LIkXV8n0lc63MQU%2Bet2CB5DGobEAi6k%3D' (2026-05-31)
• Updated input 'nixpak':
    'github:nixpak/nixpak/5bf20bb84d0b4c1870079625f65d166f00737aea?narHash=sha256-2DmT1UZMP0rr1Z3OSSYQhF2gZq2oNmUxqJwXifz7Utw%3D' (2026-05-28)
  → 'github:nixpak/nixpak/ad5ac7d24a505db29671edadfe6a8f985aa6e94e?narHash=sha256-SLjFDX7AOX%2BvstHIpGztj1JrJ5J96SxfN8kPa0ZfMVY%3D' (2026-06-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b51242d7d43689db2f3be91bd05d5b24fbb469c4?narHash=sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1%2BN6cArVE%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/6b316287bae2ee04c9b93c8c858d930fd07d7338?narHash=sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4%2BYJCYVmQ7FY%3D' (2026-06-03)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
• Updated input 'nur':
    'github:nix-community/NUR/7f8c385f2da5211ddab1fccc3daf854431ea5452?narHash=sha256-/3vb9T3rdMAQy3Vvcmy1XJ%2BSh5Tb2SIppcHm/57TUgI%3D' (2026-05-30)
  → 'github:nix-community/NUR/68708dd94f396de9e791b2779979684c9ba36550?narHash=sha256-UgIAGTmhoLKIuKvijQtGOpjD3uQbUiBEK8aZSDYe80A%3D' (2026-06-06)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4b4fca3224ab977dc515ac0bb78d00b3dfa71e00' (2026-05-22)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=b66495fcc5022681b56b61f928c7acbe910e722c' (2026-06-01)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/c591bf665727040c6cc5cb409079acb22dcce33c?narHash=sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8%3D' (2026-05-05)
  → 'github:Mic92/sops-nix/9ed65852b6257fbeae4355bc24ecfea307ca759a?narHash=sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo%3D' (2026-06-04)```