### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778857089,
-        "narHash": "sha256-TclWRW2SdFeETLaiTG4BA8C8C4m/LppQEldncqyTzAQ=",
+        "lastModified": 1780756231,
+        "narHash": "sha256-tXQxKdG5716uB9/LIkLQqQwHKf5mRSpHoZhz3lyI2Cg=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "ab2b0af63fbc9fb779d684f19149b790978be8a8",
+        "rev": "6ecde03f47172753fe5a2f334f9d3facfb7e6784",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780253365,
-        "narHash": "sha256-wcJ+6+Z+mfzBjClI0XsjOoGSW6o1RldVj6UETLzK+GQ=",
+        "lastModified": 1780771919,
+        "narHash": "sha256-cbace1ZTWYFG0luPL7OFlUxDh/t9lmPj+Isvg9hLN0k=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "236462fb93cb56e26e6a6801ba5edb6dad66be0d",
+        "rev": "3d940a534da0ba6bce60e345ff2c9c7b062087fb",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1779996637,
-        "narHash": "sha256-DcA59mHfCUfbr7EtH9YJUb3t62TcyXwC/I0QMyUs1bo=",
+        "lastModified": 1780462466,
+        "narHash": "sha256-t6c7FTqMB0skEz+4tei5v8GEyL4fRDgx24oW3LrnYiE=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "b87558b7c865628c48c1d6ff5c827b9df40e9281",
+        "rev": "bb41330bd4372672f552beda66712fb70b17f0fa",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1779959490,
-        "narHash": "sha256-FS/SbuYuRt5biCp1ja0Se12V2q3Y3p+O+rAdFQvuJT4=",
+        "lastModified": 1780413908,
+        "narHash": "sha256-T15bnskj20rdc4vJ55bFF2lVCVR8edilWn0hiYR7vVs=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "1d38a1c83db0cddff4963516eb3f6838981cb6ae",
+        "rev": "a61f943f5e94b75c5600a2968cb699d0e37945b3",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780715834,
-        "narHash": "sha256-DJwIs0RG20sjWR37mF4I7k3P3SQM97BDh9o8V5cUgo8=",
+        "lastModified": 1781308853,
+        "narHash": "sha256-BbQrn32/xDmK6HMX7QAxWChInAsbgc+ZqybMnGpit8U=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "e7ccb702a3141bfb62a6597e7863c25afff07d60",
+        "rev": "3701b3d7a3c20c5c208ce45fd530feb8eb71af78",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781190061,
+        "narHash": "sha256-QRMpLbsmlciMGv4yx75FUoIl54K02JbIX1tgdPHPw1s=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "f2b3fdb347f91dfd344ad196666a0b0fe8aad05c",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780290312,
-        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780711975,
-        "narHash": "sha256-l6oEu3L8ptc6jc6QHDyK6uMLjgSky0UjtDi6acEocDk=",
+        "lastModified": 1781317940,
+        "narHash": "sha256-uMVOhV6pVPgm2hn1WGEbIcJRWjnsyWKy8PHCUn0++iI=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "3483bc43c345f4c6c8ddd68974aa3b571da922d7",
+        "rev": "4ab59f3da3df33bf106045b856db8de875cc42c6",
         "type": "github"
       },
       "original": {
@@ -360,11 +360,11 @@
     "flake-compat_7": {
       "flake": false,
       "locked": {
-        "lastModified": 1751685974,
-        "narHash": "sha256-NKw96t+BgHIYzHUjkTK95FqYRVKB8DHpVhefWSz/kTw=",
+        "lastModified": 1777699697,
+        "narHash": "sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ=",
         "ref": "refs/heads/main",
-        "rev": "549f2762aebeff29a2e5ece7a7dc0f955281a1d1",
-        "revCount": 92,
+        "rev": "382052b74656a369c5408822af3f2501e9b1af81",
+        "revCount": 94,
         "type": "git",
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
       },
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -773,11 +773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780361225,
-        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
+        "lastModified": 1781319724,
+        "narHash": "sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
+        "rev": "8355f0a16b2dbb06a97959a918af5b239bbe05ae",
         "type": "github"
       },
       "original": {
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1781305496,
+        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
         "type": "github"
       },
       "original": {
@@ -929,11 +929,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1780694402,
-        "narHash": "sha256-gAnq7tsOsLnu/rR0tKxI5pMCjMps5CYaHU6rUdXHXyE=",
+        "lastModified": 1781352883,
+        "narHash": "sha256-EKoJrEacq3c/x3I6QcuvneduRqRDdMkAmFBYpFxbzyk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "fcbbd6d4d80033c40e3b702518e1a2ba3f479452",
+        "rev": "9556660e27b2a7e98f7e532c256b7056115042e8",
         "type": "github"
       },
       "original": {
@@ -1004,11 +1004,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779209205,
-        "narHash": "sha256-asc7NpeB8vD66gvZeYcQkaWOs2X6Jgd29vBtP17vjxo=",
+        "lastModified": 1781197920,
+        "narHash": "sha256-+xooonbcllF9V8Y0GCaOP5D9mi1jDwgsJiWE/EEPT2c=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "1cb37fad68dff5f5840010c314fed5809b4ee66f",
+        "rev": "4a622b4a741dea4e287b23bdcf6f652d23cc45b0",
         "type": "github"
       },
       "original": {
@@ -1135,11 +1135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779475241,
-        "narHash": "sha256-Nw4DN0A5krWNcPBvuWe5Gz2yuxsUUPiDgtu6SVPJQeU=",
+        "lastModified": 1780251518,
+        "narHash": "sha256-fG9xbb1SOAAJ+2kJRakp3ch+BmA/3dEg/K3PoAZTKkw=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "3cd3972b2ee658a14d2610d8494e09259e530124",
+        "rev": "40ede2e7bdec80ba5d4c443160d905e9f841ae5f",
         "type": "github"
       },
       "original": {
@@ -1353,11 +1353,11 @@
     },
     "mnw": {
       "locked": {
-        "lastModified": 1777828893,
-        "narHash": "sha256-gVWVnmyNr74BVKfhMMZDWkhx2699dhmZ2g0W8TTHtkk=",
+        "lastModified": 1778541201,
+        "narHash": "sha256-n0twkzWexzjsoDycOTvvQNuGEdg62UiNHYcFCduYpKI=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "c1c0b544bfabe6669b5a6a0383ccb475fe60258b",
+        "rev": "1a3573fc9d2486738fe0b2cacc5cd10dd5f3a445",
         "type": "github"
       },
       "original": {
@@ -1397,16 +1397,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776882296,
-        "narHash": "sha256-DWZozXwMsgvUqfVlL1mQ8dOxW7GJ/8CdyaDN+1niZRg=",
+        "lastModified": 1779233504,
+        "narHash": "sha256-YIKEyzh0NFQlD0O92LQQNMoVCDwV8yw1Xz0Iu+4ZC5U=",
         "owner": "feel-co",
         "repo": "ndg",
-        "rev": "ab7d78d4884b3a34968cf9fa3d16c0c1246d5c6e",
+        "rev": "86f6644411a64d5413711895b7cf6e0e1be465b6",
         "type": "github"
       },
       "original": {
         "owner": "feel-co",
-        "ref": "refs/tags/v2.6.0",
+        "ref": "refs/tags/v2.8.0",
         "repo": "ndg",
         "type": "github"
       }
@@ -1454,11 +1454,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780647854,
-        "narHash": "sha256-UihHR5aXPButsiQUvvnmvKxZWkRe+52nrVLd9BztXrE=",
+        "lastModified": 1780964695,
+        "narHash": "sha256-4LQ/onKqgOKkKbcripfGpegtV9rWsPooLCtErtnBj6k=",
         "ref": "refs/heads/main",
-        "rev": "4aaba8693d0fe8cb785f6b0b4497eb63cb2cf590",
-        "revCount": 130,
+        "rev": "897c1b79cd2f5a70f8189de09793f74ca0fe3890",
+        "revCount": 131,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1491,11 +1491,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1780056110,
-        "narHash": "sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU=",
+        "lastModified": 1780938415,
+        "narHash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "f9f43d826ab4014a7c302be28d7da33e12f5be37",
+        "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
         "type": "github"
       },
       "original": {
@@ -1514,11 +1514,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1780102376,
-        "narHash": "sha256-/AY1hlAixYPPuT38ldUkYzKBp7oP3tA45+7MBK+23JI=",
+        "lastModified": 1780941735,
+        "narHash": "sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "dfd985404c9632f57a0cc16654c270a772839351",
+        "rev": "fcdf02b087e1af382e3f00eda9cb3807bc8f57aa",
         "type": "github"
       },
       "original": {
@@ -1550,11 +1550,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1780633087,
-        "narHash": "sha256-l800yeumkT92AlTl7trOEeh2Of6Lx2nU6l55uWt0kxk=",
+        "lastModified": 1781324207,
+        "narHash": "sha256-RkGCo46Ra029SCFB2wvd90Mvxltqx88bWZfUeFs2Eqc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "b7ca7b683fded9623dc5f2e7f1a8d111c4a5d215",
+        "rev": "3b8dfefc46bcf4733720c9a6ec002dd23db7e354",
         "type": "github"
       },
       "original": {
@@ -1570,11 +1570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {
@@ -1628,11 +1628,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780206209,
-        "narHash": "sha256-33WNQ5sssy+8+xhUz953aEnjR1Oh828j0DgLU1TfMqE=",
+        "lastModified": 1780751787,
+        "narHash": "sha256-nWR7F46SyrLvN8Ot39XJDpVCswekGakXlOD4KsTYKW0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "45cf63e030188dd38532669b2450182bfc2d4653",
+        "rev": "00fa9a692bafc08a86061886f888b843bf7fbdb0",
         "type": "github"
       },
       "original": {
@@ -1720,11 +1720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -1736,11 +1736,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1780453794,
-        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
@@ -1880,11 +1880,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -1896,11 +1896,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1912,11 +1912,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -1934,11 +1934,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780748195,
-        "narHash": "sha256-UgIAGTmhoLKIuKvijQtGOpjD3uQbUiBEK8aZSDYe80A=",
+        "lastModified": 1781352734,
+        "narHash": "sha256-5yNLh4Af49nWq4cQGJJy5DDbDxbJa1JtfdT78yimJ98=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68708dd94f396de9e791b2779979684c9ba36550",
+        "rev": "9f22495cb9965bea49f5b31ef1a3edfc22ec1cc8",
         "type": "github"
       },
       "original": {
@@ -1960,11 +1960,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1777837065,
-        "narHash": "sha256-uRD6a4uNno3SsAw0E0E6xqbiK7pX63Ad1F37q5fyz9g=",
+        "lastModified": 1780650009,
+        "narHash": "sha256-zUN3BFopCC9J7g8cQO69s93EKCKApSwRlLWMC2bI+GY=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "7ec206a5d9a7d5d27900d81a6bb382823902276d",
+        "rev": "0b92b1783de48499303fc6e61478da34ee124482",
         "type": "github"
       },
       "original": {
@@ -1991,11 +1991,11 @@
         "sort-nvim": "sort-nvim"
       },
       "locked": {
-        "lastModified": 1777926073,
-        "narHash": "sha256-pLwDuKEhEtTZNtdvUgZFlgR3vFrndxO9mbPswoN/YaI=",
+        "lastModified": 1780956294,
+        "narHash": "sha256-MRj/0K9yGkFGTvOIfRGZ2IMTQRG/qqhF1Q0hb/w5yu0=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "14bb79368c5065b5e6e1abfe7dbeb209246fdf9a",
+        "rev": "c2b9ac4cfec0b76136f09ed7a9bd1b9c98fd7dd8",
         "type": "github"
       },
       "original": {
@@ -2050,11 +2050,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780303737,
-        "narHash": "sha256-7HgdJBG4BgAPDyHKKxWtxj7nziqsQo6zQCXtwy+L9fs=",
+        "lastModified": 1781053488,
+        "narHash": "sha256-P4WEBaKgl8flRckHxXGHzT0potPvB3x8ZFIp9gLEAMY=",
         "ref": "master",
-        "rev": "b66495fcc5022681b56b61f928c7acbe910e722c",
-        "revCount": 821,
+        "rev": "d99d87d5e5ec4e696815348692fdaaf0b6be1b2c",
+        "revCount": 822,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -2462,11 +2462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {
@@ -2539,11 +2539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778265244,
-        "narHash": "sha256-8jlPtGSsv/CQY6tVVyLF4Jjd0gnS+Zbn9yk/V13A9nM=",
+        "lastModified": 1780133819,
+        "narHash": "sha256-0YPKIY3dlnR7SPq7Z8ekFVvzFsfeiAtEj+QUI3KHrlI=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "813ea5ca9a1702a9a2d1f5836bc00172ef698968",
+        "rev": "4a170c0ba96fd37374f93d8f91c9ed91814828ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/236462fb93cb56e26e6a6801ba5edb6dad66be0d?narHash=sha256-wcJ%2B6%2BZ%2BmfzBjClI0XsjOoGSW6o1RldVj6UETLzK%2BGQ%3D' (2026-05-31)
  → 'github:xddxdd/nix-cachyos-kernel/3d940a534da0ba6bce60e345ff2c9c7b062087fb?narHash=sha256-cbace1ZTWYFG0luPL7OFlUxDh/t9lmPj%2BIsvg9hLN0k%3D' (2026-06-06)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/1d38a1c83db0cddff4963516eb3f6838981cb6ae?narHash=sha256-FS/SbuYuRt5biCp1ja0Se12V2q3Y3p%2BO%2BrAdFQvuJT4%3D' (2026-05-28)
  → 'github:CachyOS/linux-cachyos/a61f943f5e94b75c5600a2968cb699d0e37945b3?narHash=sha256-T15bnskj20rdc4vJ55bFF2lVCVR8edilWn0hiYR7vVs%3D' (2026-06-02)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/b87558b7c865628c48c1d6ff5c827b9df40e9281?narHash=sha256-DcA59mHfCUfbr7EtH9YJUb3t62TcyXwC/I0QMyUs1bo%3D' (2026-05-28)
  → 'github:CachyOS/kernel-patches/bb41330bd4372672f552beda66712fb70b17f0fa?narHash=sha256-t6c7FTqMB0skEz%2B4tei5v8GEyL4fRDgx24oW3LrnYiE%3D' (2026-06-03)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/45cf63e030188dd38532669b2450182bfc2d4653?narHash=sha256-33WNQ5sssy%2B8%2BxhUz953aEnjR1Oh828j0DgLU1TfMqE%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/00fa9a692bafc08a86061886f888b843bf7fbdb0?narHash=sha256-nWR7F46SyrLvN8Ot39XJDpVCswekGakXlOD4KsTYKW0%3D' (2026-06-06)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/e7ccb702a3141bfb62a6597e7863c25afff07d60?narHash=sha256-DJwIs0RG20sjWR37mF4I7k3P3SQM97BDh9o8V5cUgo8%3D' (2026-06-06)
  → 'github:AvengeMedia/DankMaterialShell/3701b3d7a3c20c5c208ce45fd530feb8eb71af78?narHash=sha256-BbQrn32/xDmK6HMX7QAxWChInAsbgc%2BZqybMnGpit8U%3D' (2026-06-13)
• Updated input 'darwin':
    'github:LnL7/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
  → 'github:LnL7/nix-darwin/f2b3fdb347f91dfd344ad196666a0b0fe8aad05c?narHash=sha256-QRMpLbsmlciMGv4yx75FUoIl54K02JbIX1tgdPHPw1s%3D' (2026-06-11)
• Updated input 'disko':
    'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe?narHash=sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo%3D' (2026-06-01)
  → 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1?narHash=sha256-RxWs5ND31KzTG7wvMM%2BPMfUjyNpmIEr999lqNARaM5o%3D' (2026-06-11)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/3483bc43c345f4c6c8ddd68974aa3b571da922d7?narHash=sha256-l6oEu3L8ptc6jc6QHDyK6uMLjgSky0UjtDi6acEocDk%3D' (2026-06-06)
  → 'github:AvengeMedia/dms-plugin-registry/4ab59f3da3df33bf106045b856db8de875cc42c6?narHash=sha256-uMVOhV6pVPgm2hn1WGEbIcJRWjnsyWKy8PHCUn0%2B%2BiI%3D' (2026-06-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e28654b71096e08c019d4861ca26acb646f583d8?narHash=sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA%3D' (2026-06-02)
  → 'github:nix-community/home-manager/8355f0a16b2dbb06a97959a918af5b239bbe05ae?narHash=sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M%3D' (2026-06-13)
• Updated input 'home-manager-unstable':
    'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16?narHash=sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8%3D' (2026-06-05)
  → 'github:nix-community/home-manager/c87a39aa979acc4848016d2220c6238390d84779?narHash=sha256-g8Vv4Qfc7n%2Blgov97REu3X6BeJtvYY0hlSUZR1GrGQQ%3D' (2026-06-12)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/fcbbd6d4d80033c40e3b702518e1a2ba3f479452?narHash=sha256-gAnq7tsOsLnu/rR0tKxI5pMCjMps5CYaHU6rUdXHXyE%3D' (2026-06-05)
  → 'github:hyprwm/Hyprland/9556660e27b2a7e98f7e532c256b7056115042e8?narHash=sha256-EKoJrEacq3c/x3I6QcuvneduRqRDdMkAmFBYpFxbzyk%3D' (2026-06-13)
• Updated input 'hyprland/aquamarine':
    'github:hyprwm/aquamarine/ab2b0af63fbc9fb779d684f19149b790978be8a8?narHash=sha256-TclWRW2SdFeETLaiTG4BA8C8C4m/LppQEldncqyTzAQ%3D' (2026-05-15)
  → 'github:hyprwm/aquamarine/6ecde03f47172753fe5a2f334f9d3facfb7e6784?narHash=sha256-tXQxKdG5716uB9/LIkLQqQwHKf5mRSpHoZhz3lyI2Cg%3D' (2026-06-06)
• Updated input 'hyprland/hyprutils':
    'github:hyprwm/hyprutils/3cd3972b2ee658a14d2610d8494e09259e530124?narHash=sha256-Nw4DN0A5krWNcPBvuWe5Gz2yuxsUUPiDgtu6SVPJQeU%3D' (2026-05-22)
  → 'github:hyprwm/hyprutils/40ede2e7bdec80ba5d4c443160d905e9f841ae5f?narHash=sha256-fG9xbb1SOAAJ%2B2kJRakp3ch%2BBmA/3dEg/K3PoAZTKkw%3D' (2026-05-31)
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/813ea5ca9a1702a9a2d1f5836bc00172ef698968?narHash=sha256-8jlPtGSsv/CQY6tVVyLF4Jjd0gnS%2BZbn9yk/V13A9nM%3D' (2026-05-08)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/4a170c0ba96fd37374f93d8f91c9ed91814828ac?narHash=sha256-0YPKIY3dlnR7SPq7Z8ekFVvzFsfeiAtEj%2BQUI3KHrlI%3D' (2026-05-30)
• Updated input 'hyprland-plugins':
    'github:hyprwm/hyprland-plugins/1cb37fad68dff5f5840010c314fed5809b4ee66f?narHash=sha256-asc7NpeB8vD66gvZeYcQkaWOs2X6Jgd29vBtP17vjxo%3D' (2026-05-19)
  → 'github:hyprwm/hyprland-plugins/4a622b4a741dea4e287b23bdcf6f652d23cc45b0?narHash=sha256-%2BxooonbcllF9V8Y0GCaOP5D9mi1jDwgsJiWE/EEPT2c%3D' (2026-06-11)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=4aaba8693d0fe8cb785f6b0b4497eb63cb2cf590' (2026-06-05)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=897c1b79cd2f5a70f8189de09793f74ca0fe3890' (2026-06-09)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/f9f43d826ab4014a7c302be28d7da33e12f5be37?narHash=sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU%3D' (2026-05-29)
  → 'github:YaLTeR/niri/6f1a2c5f0e8274223d4204b1f8d6f7f91538967e?narHash=sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo%3D' (2026-06-08)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:nixos/nixpkgs/a799d3e3886da994fa307f817a6bc705ae538eeb?narHash=sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY%3D' (2026-06-06)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/dfd985404c9632f57a0cc16654c270a772839351?narHash=sha256-/AY1hlAixYPPuT38ldUkYzKBp7oP3tA45%2B7MBK%2B23JI%3D' (2026-05-30)
  → 'github:LovingMelody/nix-citizen/fcdf02b087e1af382e3f00eda9cb3807bc8f57aa?narHash=sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg%3D' (2026-06-08)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
• Updated input 'nix-citizen/treefmt-nix':
    'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba?narHash=sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0%3D' (2026-04-08)
  → 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227?narHash=sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM%3D' (2026-05-31)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/b7ca7b683fded9623dc5f2e7f1a8d111c4a5d215?narHash=sha256-l800yeumkT92AlTl7trOEeh2Of6Lx2nU6l55uWt0kxk%3D' (2026-06-05)
  → 'github:fufexan/nix-gaming/3b8dfefc46bcf4733720c9a6ec002dd23db7e354?narHash=sha256-RkGCo46Ra029SCFB2wvd90Mvxltqx88bWZfUeFs2Eqc%3D' (2026-06-13)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b?narHash=sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL%2BWNQD0rJfJZQ%3D' (2026-05-29)
  → 'github:NixOS/nixpkgs/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73?narHash=sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1%2Bj%2BMRChI3TL4tAA%3D' (2026-06-06)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e?narHash=sha256-4axz3OBPTKa6LIkXV8n0lc63MQU%2Bet2CB5DGobEAi6k%3D' (2026-05-31)
  → 'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c?narHash=sha256-0BYqs8yKWkOz2Q7%2BSP18N5E5gmDKSo6LSxIVIa0wWes%3D' (2026-06-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/6b316287bae2ee04c9b93c8c858d930fd07d7338?narHash=sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4%2BYJCYVmQ7FY%3D' (2026-06-03)
  → 'github:NixOS/nixpkgs/bd0ff2d3eac24699c3664d5966b9ef36f388e2ca?narHash=sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ%3D' (2026-06-08)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
• Updated input 'nur':
    'github:nix-community/NUR/68708dd94f396de9e791b2779979684c9ba36550?narHash=sha256-UgIAGTmhoLKIuKvijQtGOpjD3uQbUiBEK8aZSDYe80A%3D' (2026-06-06)
  → 'github:nix-community/NUR/9f22495cb9965bea49f5b31ef1a3edfc22ec1cc8?narHash=sha256-5yNLh4Af49nWq4cQGJJy5DDbDxbJa1JtfdT78yimJ98%3D' (2026-06-13)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/14bb79368c5065b5e6e1abfe7dbeb209246fdf9a?narHash=sha256-pLwDuKEhEtTZNtdvUgZFlgR3vFrndxO9mbPswoN/YaI%3D' (2026-05-04)
  → 'github:derethil/nvim-config/c2b9ac4cfec0b76136f09ed7a9bd1b9c98fd7dd8?narHash=sha256-MRj/0K9yGkFGTvOIfRGZ2IMTQRG/qqhF1Q0hb/w5yu0%3D' (2026-06-08)
• Updated input 'nvim-config/nvf':
    'github:notashelf/nvf/7ec206a5d9a7d5d27900d81a6bb382823902276d?narHash=sha256-uRD6a4uNno3SsAw0E0E6xqbiK7pX63Ad1F37q5fyz9g%3D' (2026-05-03)
  → 'github:notashelf/nvf/0b92b1783de48499303fc6e61478da34ee124482?narHash=sha256-zUN3BFopCC9J7g8cQO69s93EKCKApSwRlLWMC2bI%2BGY%3D' (2026-06-05)
• Updated input 'nvim-config/nvf/flake-compat':
    'git+https://git.lix.systems/lix-project/flake-compat.git?ref=refs/heads/main&rev=549f2762aebeff29a2e5ece7a7dc0f955281a1d1' (2025-07-05)
  → 'git+https://git.lix.systems/lix-project/flake-compat.git?ref=refs/heads/main&rev=382052b74656a369c5408822af3f2501e9b1af81' (2026-05-02)
• Updated input 'nvim-config/nvf/flake-parts':
    'github:hercules-ci/flake-parts/57928607ea566b5db3ad13af0e57e921e6b12381?narHash=sha256-AnYjnFWgS49RlqX7LrC4uA%2BsCCDBj0Ry/WOJ5XWAsa0%3D' (2026-02-02)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'nvim-config/nvf/mnw':
    'github:Gerg-L/mnw/c1c0b544bfabe6669b5a6a0383ccb475fe60258b?narHash=sha256-gVWVnmyNr74BVKfhMMZDWkhx2699dhmZ2g0W8TTHtkk%3D' (2026-05-03)
  → 'github:Gerg-L/mnw/1a3573fc9d2486738fe0b2cacc5cd10dd5f3a445?narHash=sha256-n0twkzWexzjsoDycOTvvQNuGEdg62UiNHYcFCduYpKI%3D' (2026-05-11)
• Updated input 'nvim-config/nvf/ndg':
    'github:feel-co/ndg/ab7d78d4884b3a34968cf9fa3d16c0c1246d5c6e?narHash=sha256-DWZozXwMsgvUqfVlL1mQ8dOxW7GJ/8CdyaDN%2B1niZRg%3D' (2026-04-22)
  → 'github:feel-co/ndg/86f6644411a64d5413711895b7cf6e0e1be465b6?narHash=sha256-YIKEyzh0NFQlD0O92LQQNMoVCDwV8yw1Xz0Iu%2B4ZC5U%3D' (2026-05-19)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=b66495fcc5022681b56b61f928c7acbe910e722c' (2026-06-01)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=d99d87d5e5ec4e696815348692fdaaf0b6be1b2c' (2026-06-10)```