### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781292859,
-        "narHash": "sha256-etlzg6/H1NuHGTnrxxhvdmhDYQls/AMHk1IrBbNc0WM=",
+        "lastModified": 1781811723,
+        "narHash": "sha256-o0Y3TIykOACq7nwwoSzeQOhQhheI7P4x0PvHtUsoXPY=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "c57a7ab46f5e9b4eb32ed74ba6e7cd5bcd3a6e64",
+        "rev": "26da04e24aef2993ea256917be42d18f83ce8e8b",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1781257359,
-        "narHash": "sha256-J2/PBS+5u6osnWZUB7UTjLaD+S8diM+6hlOWDoX/+bw=",
+        "lastModified": 1781605133,
+        "narHash": "sha256-lmxxhcZt3qSHPS3ETDeN2OIZqC4yIa3uVpMXuIR+8Rc=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "46b45d26b536195f3ee8bc510b96b7fa47567163",
+        "rev": "3d40b72fc3c40581269f9e7a12433950f2fd6d95",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1781018471,
-        "narHash": "sha256-jQHNMqg2+Iey/WnF+RNvEs+HG3HFVdCX5W/7wne3UIM=",
+        "lastModified": 1781767284,
+        "narHash": "sha256-cjIw6fLHT1shDREFkhsMeZeRAYO7z+cnauxmpUkSdp4=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "39d9d125940996ed2eb32425ffec7f2de6ac7fba",
+        "rev": "d9b3cd77b1aa6fd4dc4baa3d876a598f884f5472",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781387463,
-        "narHash": "sha256-0pZ5HaDbC+OmELctg3IdC4GDdO+Ea8a2geqUEa2YwEs=",
+        "lastModified": 1781822553,
+        "narHash": "sha256-lINO2V/B5MxB6RXGahrPlaL07WvFiJur1WDF6rTYuyk=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "9d1a81c93c1a56298c337f24ddd2e3d87e61d09f",
+        "rev": "4203148cabb74abfb17e5c02f3b76c28b52601e7",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781405131,
-        "narHash": "sha256-j1PHF0WNWmiBtk2jBnrfxGa67M8lGV3QPP/KBdYQOE0=",
+        "lastModified": 1781922826,
+        "narHash": "sha256-0ZYx2LmBj9fvF3Y8gIlYhGaIvKOh5CQb9TwSXd4wINw=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "2504757530335213814d8c7f75816260bc1ace83",
+        "rev": "46504c36544b88000a23c41b2cfe9e10dc7fde3c",
         "type": "github"
       },
       "original": {
@@ -554,7 +554,10 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": [
+          "nix-gaming",
+          "flake-compat"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nix-gaming",
@@ -625,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778930899,
-        "narHash": "sha256-OOEWyt8ma7QAysDbiP65J7li7KIdtZfnbA11gFnwyEI=",
+        "lastModified": 1781499420,
+        "narHash": "sha256-vy0EiuiLRKWbXYOqdEKoy5ImlbHcdMC52x9BcC/MwQ8=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "af4331c44f13977b6964745454eadcfee2d244d1",
+        "rev": "86c7c78a840b44b1a0a5cbc7e9baa0154c0d0f3f",
         "type": "github"
       },
       "original": {
@@ -921,11 +924,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780964695,
-        "narHash": "sha256-4LQ/onKqgOKkKbcripfGpegtV9rWsPooLCtErtnBj6k=",
+        "lastModified": 1781779431,
+        "narHash": "sha256-BibyxZQXVQvl/wyD9CSAmwVipK9PvOMyQjI7k2aNwZs=",
         "ref": "refs/heads/main",
-        "rev": "897c1b79cd2f5a70f8189de09793f74ca0fe3890",
-        "revCount": 131,
+        "rev": "b6e1775e74667da4daafd9d6b388f18f05048aa4",
+        "revCount": 132,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -981,11 +984,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1780941735,
-        "narHash": "sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg=",
+        "lastModified": 1781627161,
+        "narHash": "sha256-ETstDjp1kxWomsq6Pz1090l6R70k+v/3tH9gyFzbRVM=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "fcdf02b087e1af382e3f00eda9cb3807bc8f57aa",
+        "rev": "d1d8e63628ee410d0af396e4d2e6d57b4db89cc2",
         "type": "github"
       },
       "original": {
@@ -1001,11 +1004,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781190061,
-        "narHash": "sha256-QRMpLbsmlciMGv4yx75FUoIl54K02JbIX1tgdPHPw1s=",
+        "lastModified": 1781772065,
+        "narHash": "sha256-xIbRSwDB1GBAUsWsQZUjudGfAGQt3BOpsWaO/ugVa4w=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f2b3fdb347f91dfd344ad196666a0b0fe8aad05c",
+        "rev": "adda04f0bf4819575b1978c2f8d78401b3c2be12",
         "type": "github"
       },
       "original": {
@@ -1033,16 +1036,17 @@
     },
     "nix-gaming": {
       "inputs": {
+        "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts_4",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1781411167,
-        "narHash": "sha256-GLf7zW8Oe+vMP2nNajKUShYkW0FsZ2nMkSsihX2cR6o=",
+        "lastModified": 1781943281,
+        "narHash": "sha256-Ga206P+IEguVLUoT87QvshjrLzzkoA3m6QMXySP+S1A=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "0c680d0426cf04641f718d083bd352e20bc3e0dc",
+        "rev": "14e578b7b8d0696bbe582fa6fee79b8d1308efc8",
         "type": "github"
       },
       "original": {
@@ -1080,11 +1084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781356953,
-        "narHash": "sha256-Z6+m8YqDkW/7wF0RSqbisR2TbBM6opAT60eTOe/o91g=",
+        "lastModified": 1781749433,
+        "narHash": "sha256-Pb2+bL5WRZLIzb/NMdjHEe9UBcU/yGfb1QWlyzyMTic=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "26b2c3bfcc07c548ffa4c66121b397303bcf50f5",
+        "rev": "be97295fa81fe743b9753449143dd4931e51d63c",
         "type": "github"
       },
       "original": {
@@ -1095,11 +1099,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781246015,
-        "narHash": "sha256-C3D5TBgght7LBaqm5oGNRf6CynGl5lGED4jcDw2ZOOk=",
+        "lastModified": 1781793837,
+        "narHash": "sha256-T9/Q/A5B/Q1hC65fdwCz0aKVN7u1MDXGQXMKgoMQ1Hw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bd229cbe77d7746d64a1e8c1a6f6cc08f606fc4",
+        "rev": "05eced6879632fc2f62fec56f2e33269157984ef",
         "type": "github"
       },
       "original": {
@@ -1188,11 +1192,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1320,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -1370,11 +1374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781474283,
-        "narHash": "sha256-pz9fqYrp8qaoyinv42xsqMGp8U2kROe7KkIEuqnBXEU=",
+        "lastModified": 1781958832,
+        "narHash": "sha256-/uNI3+xnxwzMfOYXIqK/PrhRKPYYMwyHH1LMOby19AI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "43ba01f6a5b64dc58a0bd8997095d7f7ba12d363",
+        "rev": "d37bf883c9568e251a5fa14577da1193583b8d45",
         "type": "github"
       },
       "original": {
@@ -1467,11 +1471,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781053488,
-        "narHash": "sha256-P4WEBaKgl8flRckHxXGHzT0potPvB3x8ZFIp9gLEAMY=",
+        "lastModified": 1781847791,
+        "narHash": "sha256-Mo2YtNEGlcySnbq0YuP3nUKMAQCMAfE+TcCffo5vzD8=",
         "ref": "master",
-        "rev": "d99d87d5e5ec4e696815348692fdaaf0b6be1b2c",
-        "revCount": 822,
+        "rev": "68c2c85c33845385f7ab8147b32f1450b1e468e0",
+        "revCount": 824,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1541,11 +1545,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780547341,
-        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "lastModified": 1781943681,
+        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/c57a7ab46f5e9b4eb32ed74ba6e7cd5bcd3a6e64?narHash=sha256-etlzg6/H1NuHGTnrxxhvdmhDYQls/AMHk1IrBbNc0WM%3D' (2026-06-12)
  → 'github:xddxdd/nix-cachyos-kernel/26da04e24aef2993ea256917be42d18f83ce8e8b?narHash=sha256-o0Y3TIykOACq7nwwoSzeQOhQhheI7P4x0PvHtUsoXPY%3D' (2026-06-18)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/39d9d125940996ed2eb32425ffec7f2de6ac7fba?narHash=sha256-jQHNMqg2%2BIey/WnF%2BRNvEs%2BHG3HFVdCX5W/7wne3UIM%3D' (2026-06-09)
  → 'github:CachyOS/linux-cachyos/d9b3cd77b1aa6fd4dc4baa3d876a598f884f5472?narHash=sha256-cjIw6fLHT1shDREFkhsMeZeRAYO7z%2BcnauxmpUkSdp4%3D' (2026-06-18)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/46b45d26b536195f3ee8bc510b96b7fa47567163?narHash=sha256-J2/PBS%2B5u6osnWZUB7UTjLaD%2BS8diM%2B6hlOWDoX/%2Bbw%3D' (2026-06-12)
  → 'github:CachyOS/kernel-patches/3d40b72fc3c40581269f9e7a12433950f2fd6d95?narHash=sha256-lmxxhcZt3qSHPS3ETDeN2OIZqC4yIa3uVpMXuIR%2B8Rc%3D' (2026-06-16)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/7bd229cbe77d7746d64a1e8c1a6f6cc08f606fc4?narHash=sha256-C3D5TBgght7LBaqm5oGNRf6CynGl5lGED4jcDw2ZOOk%3D' (2026-06-12)
  → 'github:NixOS/nixpkgs/05eced6879632fc2f62fec56f2e33269157984ef?narHash=sha256-T9/Q/A5B/Q1hC65fdwCz0aKVN7u1MDXGQXMKgoMQ1Hw%3D' (2026-06-18)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/9d1a81c93c1a56298c337f24ddd2e3d87e61d09f?narHash=sha256-0pZ5HaDbC%2BOmELctg3IdC4GDdO%2BEa8a2geqUEa2YwEs%3D' (2026-06-13)
  → 'github:AvengeMedia/DankMaterialShell/4203148cabb74abfb17e5c02f3b76c28b52601e7?narHash=sha256-lINO2V/B5MxB6RXGahrPlaL07WvFiJur1WDF6rTYuyk%3D' (2026-06-18)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/2504757530335213814d8c7f75816260bc1ace83?narHash=sha256-j1PHF0WNWmiBtk2jBnrfxGa67M8lGV3QPP/KBdYQOE0%3D' (2026-06-14)
  → 'github:AvengeMedia/dms-plugin-registry/46504c36544b88000a23c41b2cfe9e10dc7fde3c?narHash=sha256-0ZYx2LmBj9fvF3Y8gIlYhGaIvKOh5CQb9TwSXd4wINw%3D' (2026-06-20)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=897c1b79cd2f5a70f8189de09793f74ca0fe3890' (2026-06-09)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=b6e1775e74667da4daafd9d6b388f18f05048aa4' (2026-06-18)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/fcdf02b087e1af382e3f00eda9cb3807bc8f57aa?narHash=sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg%3D' (2026-06-08)
  → 'github:LovingMelody/nix-citizen/d1d8e63628ee410d0af396e4d2e6d57b4db89cc2?narHash=sha256-ETstDjp1kxWomsq6Pz1090l6R70k%2Bv/3tH9gyFzbRVM%3D' (2026-06-16)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/f2b3fdb347f91dfd344ad196666a0b0fe8aad05c?narHash=sha256-QRMpLbsmlciMGv4yx75FUoIl54K02JbIX1tgdPHPw1s%3D' (2026-06-11)
  → 'github:LnL7/nix-darwin/adda04f0bf4819575b1978c2f8d78401b3c2be12?narHash=sha256-xIbRSwDB1GBAUsWsQZUjudGfAGQt3BOpsWaO/ugVa4w%3D' (2026-06-18)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/0c680d0426cf04641f718d083bd352e20bc3e0dc?narHash=sha256-GLf7zW8Oe%2BvMP2nNajKUShYkW0FsZ2nMkSsihX2cR6o%3D' (2026-06-14)
  → 'github:fufexan/nix-gaming/14e578b7b8d0696bbe582fa6fee79b8d1308efc8?narHash=sha256-Ga206P%2BIEguVLUoT87QvshjrLzzkoA3m6QMXySP%2BS1A%3D' (2026-06-20)
• Added input 'nix-gaming/flake-compat':
    'github:NixOS/flake-compat/5edf11c44bc78a0d334f6334cdaf7d60d732daab?narHash=sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns%3D' (2025-12-29)
• Updated input 'nix-gaming/git-hooks/flake-compat':
    'github:NixOS/flake-compat/5edf11c44bc78a0d334f6334cdaf7d60d732daab?narHash=sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns%3D' (2025-12-29)
  → follows 'nix-gaming/flake-compat'
• Updated input 'nixpak':
    'github:nixpak/nixpak/26b2c3bfcc07c548ffa4c66121b397303bcf50f5?narHash=sha256-Z6%2Bm8YqDkW/7wF0RSqbisR2TbBM6opAT60eTOe/o91g%3D' (2026-06-13)
  → 'github:nixpak/nixpak/be97295fa81fe743b9753449143dd4931e51d63c?narHash=sha256-Pb2%2BbL5WRZLIzb/NMdjHEe9UBcU/yGfb1QWlyzyMTic%3D' (2026-06-18)
• Updated input 'nixpak/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/af4331c44f13977b6964745454eadcfee2d244d1?narHash=sha256-OOEWyt8ma7QAysDbiP65J7li7KIdtZfnbA11gFnwyEI%3D' (2026-05-16)
  → 'github:hercules-ci/hercules-ci-effects/86c7c78a840b44b1a0a5cbc7e9baa0154c0d0f3f?narHash=sha256-vy0EiuiLRKWbXYOqdEKoy5ImlbHcdMC52x9BcC/MwQ8%3D' (2026-06-15)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
  → 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
• Updated input 'nur':
    'github:nix-community/NUR/43ba01f6a5b64dc58a0bd8997095d7f7ba12d363?narHash=sha256-pz9fqYrp8qaoyinv42xsqMGp8U2kROe7KkIEuqnBXEU%3D' (2026-06-14)
  → 'github:nix-community/NUR/d37bf883c9568e251a5fa14577da1193583b8d45?narHash=sha256-/uNI3%2BxnxwzMfOYXIqK/PrhRKPYYMwyHH1LMOby19AI%3D' (2026-06-20)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=d99d87d5e5ec4e696815348692fdaaf0b6be1b2c' (2026-06-10)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=68c2c85c33845385f7ab8147b32f1450b1e468e0' (2026-06-19)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/9ed65852b6257fbeae4355bc24ecfea307ca759a?narHash=sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo%3D' (2026-06-04)
  → 'github:Mic92/sops-nix/420f8d2e9882911f65cfac15cc706f639ba96cca?narHash=sha256-NFHmA7H47adqiyp%2B0iEOyZOQhmigDqA/NBAlf4imB6U%3D' (2026-06-20)```