### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779995374,
-        "narHash": "sha256-Nw9Gk5OC3gvB/sDB1PCyFrDgLzrKcDr7vooFnm5fJTw=",
+        "lastModified": 1782721201,
+        "narHash": "sha256-7asJHLsyXrNs5hjPrNjuEtyrmbdxrEtrhWx9+GkoqNU=",
         "owner": "saatvik333",
         "repo": "wayland-bongocat",
-        "rev": "2d4f1a28760acec7881bc90a217ac061bd97174e",
+        "rev": "e46f7f5c2cff192a9884de7eeda946292abb0d2c",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781811723,
-        "narHash": "sha256-o0Y3TIykOACq7nwwoSzeQOhQhheI7P4x0PvHtUsoXPY=",
+        "lastModified": 1783018940,
+        "narHash": "sha256-fQ4+88WbgRkQYCMF37GYNuthHojlYhvfIAKJpSynVyk=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "26da04e24aef2993ea256917be42d18f83ce8e8b",
+        "rev": "3a4f4055db5f96ce696b5704c996d5bffbcda58d",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1781605133,
-        "narHash": "sha256-lmxxhcZt3qSHPS3ETDeN2OIZqC4yIa3uVpMXuIR+8Rc=",
+        "lastModified": 1782814529,
+        "narHash": "sha256-YGYe7cy8vUFguQzdCt6FP1B/viF53cJdFZhNJ8Rpp5Y=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "3d40b72fc3c40581269f9e7a12433950f2fd6d95",
+        "rev": "f98908d8b5cacc4c24a6039ffd9f41f6a0de4ba2",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1781767284,
-        "narHash": "sha256-cjIw6fLHT1shDREFkhsMeZeRAYO7z+cnauxmpUkSdp4=",
+        "lastModified": 1782811891,
+        "narHash": "sha256-xLfMSeSKKHmYCESe9Ca24eSXUsEV5z1oC59Cqfb7s8U=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "d9b3cd77b1aa6fd4dc4baa3d876a598f884f5472",
+        "rev": "dc2bfb6686ce41d04185d1a3a11b2b6fc24aeca6",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781822553,
-        "narHash": "sha256-lINO2V/B5MxB6RXGahrPlaL07WvFiJur1WDF6rTYuyk=",
+        "lastModified": 1783142816,
+        "narHash": "sha256-wfuhflRtE2Q+sXLJsobste6uCJdEqr2pHA7RL0NEuEg=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "4203148cabb74abfb17e5c02f3b76c28b52601e7",
+        "rev": "0509694d78c99e3065ab3b09c73bf05df460abb7",
         "type": "github"
       },
       "original": {
@@ -193,16 +193,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1781922826,
-        "narHash": "sha256-0ZYx2LmBj9fvF3Y8gIlYhGaIvKOh5CQb9TwSXd4wINw=",
+        "lastModified": 1783146329,
+        "narHash": "sha256-koldAEI5lE97dQA6GD2/ZqZrpAVXkNy1ojq0YSBwObg=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "46504c36544b88000a23c41b2cfe9e10dc7fde3c",
+        "rev": "0cd752bbf6550c53926fee5f2f301828d4847097",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "khal-notify",
+          "naersk",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752475459,
+        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
@@ -258,17 +281,15 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
+        "lastModified": 1777699697,
+        "narHash": "sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ=",
+        "rev": "382052b74656a369c5408822af3f2501e9b1af81",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/flake-compat/archive/382052b74656a369c5408822af3f2501e9b1af81.tar.gz?rev=382052b74656a369c5408822af3f2501e9b1af81"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/flake-compat/archive/main.tar.gz"
       }
     },
     "flake-compat_5": {
@@ -338,11 +359,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -376,11 +397,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -583,11 +604,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -666,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781319724,
-        "narHash": "sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M=",
+        "lastModified": 1782704057,
+        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8355f0a16b2dbb06a97959a918af5b239bbe05ae",
+        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
         "type": "github"
       },
       "original": {
@@ -802,11 +823,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1714380393,
-        "narHash": "sha256-Muz1tPdg0lOd+Amquc+q/z5K5RHYe2U9nDkZktx2VXE=",
+        "lastModified": 1782890725,
+        "narHash": "sha256-2JxTrEyUel7LDbjhVXvv/hQC9aQSsI5Z/ny+SSVoshw=",
         "owner": "martiert",
         "repo": "khal_notifications",
-        "rev": "f920db65d410c16fd1b8d6039ecbe398665cd497",
+        "rev": "325152fe525284bde21f7c7f28591aa93b15f9f4",
         "type": "github"
       },
       "original": {
@@ -872,17 +893,18 @@
     },
     "naersk": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": [
           "khal-notify",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1713520724,
-        "narHash": "sha256-CO8MmVDmqZX2FovL75pu5BvwhW+Vugc7Q6ze7Hj8heI=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "c5037590290c6c7dae2e42e7da1e247e54ed2d49",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {
@@ -958,11 +980,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1781779431,
-        "narHash": "sha256-BibyxZQXVQvl/wyD9CSAmwVipK9PvOMyQjI7k2aNwZs=",
+        "lastModified": 1783123730,
+        "narHash": "sha256-QbTdquZaVN7ZVH4EJgpQTeqrdkwnJrN1TgQJFa3f/tc=",
         "ref": "refs/heads/main",
-        "rev": "b6e1775e74667da4daafd9d6b388f18f05048aa4",
-        "revCount": 132,
+        "rev": "c7d0c5f85ff82a71ef10c27591367708af693c26",
+        "revCount": 137,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -995,11 +1017,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1780938415,
-        "narHash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
+        "lastModified": 1781781064,
+        "narHash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
+        "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
         "type": "github"
       },
       "original": {
@@ -1018,11 +1040,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1781627161,
-        "narHash": "sha256-ETstDjp1kxWomsq6Pz1090l6R70k+v/3tH9gyFzbRVM=",
+        "lastModified": 1782850610,
+        "narHash": "sha256-SAl7vyRyLUkt0XtcE2fAs4cWD4fOCZGI3RjBZ5U/yNU=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "d1d8e63628ee410d0af396e4d2e6d57b4db89cc2",
+        "rev": "7db41f8024ff84cc5ecc532560a5b6598ca65208",
         "type": "github"
       },
       "original": {
@@ -1098,11 +1120,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1781943281,
-        "narHash": "sha256-Ga206P+IEguVLUoT87QvshjrLzzkoA3m6QMXySP+S1A=",
+        "lastModified": 1782934759,
+        "narHash": "sha256-1YTEea1x4jfVZkwj2P9K+EpN4huU4PlCsMXbl4ili/A=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "14e578b7b8d0696bbe582fa6fee79b8d1308efc8",
+        "rev": "a34118c61059e72f9276680400c4f52e8b4db4dd",
         "type": "github"
       },
       "original": {
@@ -1118,11 +1140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1783023993,
+        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781793837,
-        "narHash": "sha256-T9/Q/A5B/Q1hC65fdwCz0aKVN7u1MDXGQXMKgoMQ1Hw=",
+        "lastModified": 1783003425,
+        "narHash": "sha256-CLVsEepcFedoiIwXVlAYam9bbTt3mmTJXgGrvoLDDFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05eced6879632fc2f62fec56f2e33269157984ef",
+        "rev": "6147971a7160e60cf691651d97cc8411395f5d90",
         "type": "github"
       },
       "original": {
@@ -1171,11 +1193,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1279,11 +1301,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -1391,11 +1413,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -1407,11 +1429,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -1423,11 +1445,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1781328464,
-        "narHash": "sha256-j9uBlHI0eJ9zWU9IlF6SlBBPdeJu30hcvar31IRKHpw=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a722a7155bfc9fbe657f28d26b71860d95324bc",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {
@@ -1439,11 +1461,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1781216227,
-        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "lastModified": 1782999065,
+        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
         "type": "github"
       },
       "original": {
@@ -1461,11 +1483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781958832,
-        "narHash": "sha256-/uNI3+xnxwzMfOYXIqK/PrhRKPYYMwyHH1LMOby19AI=",
+        "lastModified": 1783167752,
+        "narHash": "sha256-2Vq4lZBAWMgKVF+OrDBOf03VdSAYQrViOy2e+4wWE+4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d37bf883c9568e251a5fa14577da1193583b8d45",
+        "rev": "8e66e7ac0919e2eb3be1711281b1f3154caace4e",
         "type": "github"
       },
       "original": {
@@ -1561,11 +1583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780784241,
-        "narHash": "sha256-fRcQa6lF9J3xtyGW7MrIqFmruP8KnBlq+GzUDngDumE=",
+        "lastModified": 1781785859,
+        "narHash": "sha256-NKq4Rgkc5LRoAOXxv/HgMA22m3l4YRXjfDBAfxJt9u4=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "52f40510765996e15f20fd36acd73c096651519e",
+        "rev": "9dff917b552fcfe50b5da5f0b6df69a63b507d7d",
         "type": "github"
       },
       "original": {
@@ -1581,11 +1603,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781847791,
-        "narHash": "sha256-Mo2YtNEGlcySnbq0YuP3nUKMAQCMAfE+TcCffo5vzD8=",
+        "lastModified": 1782811879,
+        "narHash": "sha256-7YAUrV8YoDFnvOtFAGzdMVgNh25h7nOg3PxjRmLAHaE=",
         "ref": "master",
-        "rev": "68c2c85c33845385f7ab8147b32f1450b1e468e0",
-        "revCount": 824,
+        "rev": "1661ef100a431a470ed2c42e6d06539b77edf826",
+        "revCount": 825,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1633,6 +1655,23 @@
         "yazi-gruvbox-dark": "yazi-gruvbox-dark"
       }
     },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752428706,
+        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
     "secrets": {
       "flake": false,
       "locked": {
@@ -1657,11 +1696,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781943681,
-        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
+        "lastModified": 1783104586,
+        "narHash": "sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
+        "rev": "1ebd41717762d837d5115f7108522c29cdb00fbb",
         "type": "github"
       },
       "original": {
@@ -1809,11 +1848,11 @@
     "tmux-power-zoom": {
       "flake": false,
       "locked": {
-        "lastModified": 1767030385,
-        "narHash": "sha256-3nogJO/kpFb5ruzBfSsZbrnGcmy+uFWlxBZn3KkuSmo=",
+        "lastModified": 1782858867,
+        "narHash": "sha256-fpsCR0TciaVB5NKFgVKpBFaPdr38b2r6QCh8P3hdXUg=",
         "owner": "jaclu",
         "repo": "tmux-power-zoom",
-        "rev": "f3be607863839c96a8472cb3ac3cda9a86c062a7",
+        "rev": "1bfa1350f735adaaf844ef9a1db082b81efeb47d",
         "type": "github"
       },
       "original": {
@@ -1900,11 +1939,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -1934,11 +1973,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1779745227,
-        "narHash": "sha256-yqY7RtEJGJiENzR0GwL6q69tSAy6xAAmAcLuIhLjPf8=",
+        "lastModified": 1781226823,
+        "narHash": "sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi+sc=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "5d1efbc9dc3ab1c10160b656e0247f3325daf0f2",
+        "rev": "8575d0ef55d70f9b4c46b6bffb3accf912217e1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'bongocat':
    'github:saatvik333/wayland-bongocat/2d4f1a28760acec7881bc90a217ac061bd97174e?narHash=sha256-Nw9Gk5OC3gvB/sDB1PCyFrDgLzrKcDr7vooFnm5fJTw%3D' (2026-05-28)
  → 'github:saatvik333/wayland-bongocat/e46f7f5c2cff192a9884de7eeda946292abb0d2c?narHash=sha256-7asJHLsyXrNs5hjPrNjuEtyrmbdxrEtrhWx9%2BGkoqNU%3D' (2026-06-29)
• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/26da04e24aef2993ea256917be42d18f83ce8e8b?narHash=sha256-o0Y3TIykOACq7nwwoSzeQOhQhheI7P4x0PvHtUsoXPY%3D' (2026-06-18)
  → 'github:xddxdd/nix-cachyos-kernel/3a4f4055db5f96ce696b5704c996d5bffbcda58d?narHash=sha256-fQ4%2B88WbgRkQYCMF37GYNuthHojlYhvfIAKJpSynVyk%3D' (2026-07-02)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/d9b3cd77b1aa6fd4dc4baa3d876a598f884f5472?narHash=sha256-cjIw6fLHT1shDREFkhsMeZeRAYO7z%2BcnauxmpUkSdp4%3D' (2026-06-18)
  → 'github:CachyOS/linux-cachyos/dc2bfb6686ce41d04185d1a3a11b2b6fc24aeca6?narHash=sha256-xLfMSeSKKHmYCESe9Ca24eSXUsEV5z1oC59Cqfb7s8U%3D' (2026-06-30)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/3d40b72fc3c40581269f9e7a12433950f2fd6d95?narHash=sha256-lmxxhcZt3qSHPS3ETDeN2OIZqC4yIa3uVpMXuIR%2B8Rc%3D' (2026-06-16)
  → 'github:CachyOS/kernel-patches/f98908d8b5cacc4c24a6039ffd9f41f6a0de4ba2?narHash=sha256-YGYe7cy8vUFguQzdCt6FP1B/viF53cJdFZhNJ8Rpp5Y%3D' (2026-06-30)
• Updated input 'cachyos-kernel/flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'cachyos-kernel/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/05eced6879632fc2f62fec56f2e33269157984ef?narHash=sha256-T9/Q/A5B/Q1hC65fdwCz0aKVN7u1MDXGQXMKgoMQ1Hw%3D' (2026-06-18)
  → 'github:NixOS/nixpkgs/6147971a7160e60cf691651d97cc8411395f5d90?narHash=sha256-CLVsEepcFedoiIwXVlAYam9bbTt3mmTJXgGrvoLDDFM%3D' (2026-07-02)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/4203148cabb74abfb17e5c02f3b76c28b52601e7?narHash=sha256-lINO2V/B5MxB6RXGahrPlaL07WvFiJur1WDF6rTYuyk%3D' (2026-06-18)
  → 'github:AvengeMedia/DankMaterialShell/0509694d78c99e3065ab3b09c73bf05df460abb7?narHash=sha256-wfuhflRtE2Q%2BsXLJsobste6uCJdEqr2pHA7RL0NEuEg%3D' (2026-07-04)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/46504c36544b88000a23c41b2cfe9e10dc7fde3c?narHash=sha256-0ZYx2LmBj9fvF3Y8gIlYhGaIvKOh5CQb9TwSXd4wINw%3D' (2026-06-20)
  → 'github:AvengeMedia/dms-plugin-registry/0cd752bbf6550c53926fee5f2f301828d4847097?narHash=sha256-koldAEI5lE97dQA6GD2/ZqZrpAVXkNy1ojq0YSBwObg%3D' (2026-07-04)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8355f0a16b2dbb06a97959a918af5b239bbe05ae?narHash=sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M%3D' (2026-06-13)
  → 'github:nix-community/home-manager/868d0a692de703c2de98fab61968e4e310b7c28e?narHash=sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck%3D' (2026-06-29)
• Updated input 'khal-notify':
    'github:martiert/khal_notifications/f920db65d410c16fd1b8d6039ecbe398665cd497?narHash=sha256-Muz1tPdg0lOd%2BAmquc%2Bq/z5K5RHYe2U9nDkZktx2VXE%3D' (2024-04-29)
  → 'github:martiert/khal_notifications/325152fe525284bde21f7c7f28591aa93b15f9f4?narHash=sha256-2JxTrEyUel7LDbjhVXvv/hQC9aQSsI5Z/ny%2BSSVoshw%3D' (2026-07-01)
• Updated input 'khal-notify/naersk':
    'github:nix-community/naersk/c5037590290c6c7dae2e42e7da1e247e54ed2d49?narHash=sha256-CO8MmVDmqZX2FovL75pu5BvwhW%2BVugc7Q6ze7Hj8heI%3D' (2024-04-19)
  → 'github:nix-community/naersk/9aa07bb0256d300219b30622d2454e85f7f3667e?narHash=sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo%3D' (2026-06-23)
• Added input 'khal-notify/naersk/fenix':
    'github:nix-community/fenix/bf0d6f70f4c9a9cf8845f992105652173f4b617f?narHash=sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU%3D' (2025-07-14)
• Added input 'khal-notify/naersk/fenix/nixpkgs':
    follows 'khal-notify/naersk/nixpkgs'
• Added input 'khal-notify/naersk/fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/591e3b7624be97e4443ea7b5542c191311aa141d?narHash=sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu%2BQEnJn2Sfg%3D' (2025-07-13)
• Updated input 'khal-notify/utils':
    'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a?narHash=sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ%3D' (2024-03-11)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=b6e1775e74667da4daafd9d6b388f18f05048aa4' (2026-06-18)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=c7d0c5f85ff82a71ef10c27591367708af693c26' (2026-07-04)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/6f1a2c5f0e8274223d4204b1f8d6f7f91538967e?narHash=sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo%3D' (2026-06-08)
  → 'github:YaLTeR/niri/49fc6117fd6c043adaa2ead316b82db5ed735d36?narHash=sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0%3D' (2026-06-18)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/a799d3e3886da994fa307f817a6bc705ae538eeb?narHash=sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY%3D' (2026-06-06)
  → 'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
• Updated input 'niri-nix/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/5d1efbc9dc3ab1c10160b656e0247f3325daf0f2?narHash=sha256-yqY7RtEJGJiENzR0GwL6q69tSAy6xAAmAcLuIhLjPf8%3D' (2026-05-25)
  → 'github:Supreeeme/xwayland-satellite/8575d0ef55d70f9b4c46b6bffb3accf912217e1e?narHash=sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi%2Bsc%3D' (2026-06-12)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/d1d8e63628ee410d0af396e4d2e6d57b4db89cc2?narHash=sha256-ETstDjp1kxWomsq6Pz1090l6R70k%2Bv/3tH9gyFzbRVM%3D' (2026-06-16)
  → 'github:LovingMelody/nix-citizen/7db41f8024ff84cc5ecc532560a5b6598ca65208?narHash=sha256-SAl7vyRyLUkt0XtcE2fAs4cWD4fOCZGI3RjBZ5U/yNU%3D' (2026-06-30)
• Updated input 'nix-citizen/flake-compat':
    'github:NixOS/flake-compat/5edf11c44bc78a0d334f6334cdaf7d60d732daab?narHash=sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns%3D' (2025-12-29)
  → 'https://git.lix.systems/api/v1/repos/lix-project/flake-compat/archive/382052b74656a369c5408822af3f2501e9b1af81.tar.gz?narHash=sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ%3D&rev=382052b74656a369c5408822af3f2501e9b1af81' (2026-05-02)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
  → 'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8?narHash=sha256-oPXCU/SSUokcGaJREHibG1CBX3%2Bs/W7orDWQOZDsEeQ%3D' (2026-06-29)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/14e578b7b8d0696bbe582fa6fee79b8d1308efc8?narHash=sha256-Ga206P%2BIEguVLUoT87QvshjrLzzkoA3m6QMXySP%2BS1A%3D' (2026-06-20)
  → 'github:fufexan/nix-gaming/a34118c61059e72f9276680400c4f52e8b4db4dd?narHash=sha256-1YTEea1x4jfVZkwj2P9K%2BEpN4huU4PlCsMXbl4ili/A%3D' (2026-07-01)
• Updated input 'nix-gaming/git-hooks':
    'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
  → 'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/5a722a7155bfc9fbe657f28d26b71860d95324bc?narHash=sha256-j9uBlHI0eJ9zWU9IlF6SlBBPdeJu30hcvar31IRKHpw%3D' (2026-06-13)
  → 'github:NixOS/nixpkgs/89570f24e97e614aa34aa9ab1c927b6578a43775?narHash=sha256-EMzXKmnOtBQ2MnvpiNOm7E%2BkOMvdPrIKaeg52Tip2Uk%3D' (2026-06-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1?narHash=sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0%3D' (2026-06-14)
  → 'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074?narHash=sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o%3D' (2026-07-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a0374025a863d007d98e3297f6aa46cc3141c2f0?narHash=sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE%3D' (2026-06-11)
  → 'github:NixOS/nixpkgs/80d591ed473cfc46329932c2aadac9b435342c7c?narHash=sha256-5Dgj5%2BpIQYZKrXUGaLCk7CKfN3MmpwIhO94%2B%2BWVxvng%3D' (2026-07-02)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
  → 'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/d37bf883c9568e251a5fa14577da1193583b8d45?narHash=sha256-/uNI3%2BxnxwzMfOYXIqK/PrhRKPYYMwyHH1LMOby19AI%3D' (2026-06-20)
  → 'github:nix-community/NUR/8e66e7ac0919e2eb3be1711281b1f3154caace4e?narHash=sha256-2Vq4lZBAWMgKVF%2BOrDBOf03VdSAYQrViOy2e%2B4wWE%2B4%3D' (2026-07-04)
• Updated input 'paneru':
    'github:karinushka/paneru/52f40510765996e15f20fd36acd73c096651519e?narHash=sha256-fRcQa6lF9J3xtyGW7MrIqFmruP8KnBlq%2BGzUDngDumE%3D' (2026-06-06)
  → 'github:karinushka/paneru/9dff917b552fcfe50b5da5f0b6df69a63b507d7d?narHash=sha256-NKq4Rgkc5LRoAOXxv/HgMA22m3l4YRXjfDBAfxJt9u4%3D' (2026-06-18)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=68c2c85c33845385f7ab8147b32f1450b1e468e0' (2026-06-19)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=1661ef100a431a470ed2c42e6d06539b77edf826' (2026-06-30)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/420f8d2e9882911f65cfac15cc706f639ba96cca?narHash=sha256-NFHmA7H47adqiyp%2B0iEOyZOQhmigDqA/NBAlf4imB6U%3D' (2026-06-20)
  → 'github:Mic92/sops-nix/1ebd41717762d837d5115f7108522c29cdb00fbb?narHash=sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs%3D' (2026-07-03)
• Updated input 'tmux-power-zoom':
    'github:jaclu/tmux-power-zoom/f3be607863839c96a8472cb3ac3cda9a86c062a7?narHash=sha256-3nogJO/kpFb5ruzBfSsZbrnGcmy%2BuFWlxBZn3KkuSmo%3D' (2025-12-29)
  → 'github:jaclu/tmux-power-zoom/1bfa1350f735adaaf844ef9a1db082b81efeb47d?narHash=sha256-fpsCR0TciaVB5NKFgVKpBFaPdr38b2r6QCh8P3hdXUg%3D' (2026-06-30)```