### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783018940,
-        "narHash": "sha256-fQ4+88WbgRkQYCMF37GYNuthHojlYhvfIAKJpSynVyk=",
+        "lastModified": 1783710455,
+        "narHash": "sha256-w5ALD125oHIa5MVhoBXo3qx2ktvRvJ+1p8UScV9f8OI=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "3a4f4055db5f96ce696b5704c996d5bffbcda58d",
+        "rev": "4673c8f6d48baf2ec3f14b6a9f8c4ecfb0810d6f",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1782814529,
-        "narHash": "sha256-YGYe7cy8vUFguQzdCt6FP1B/viF53cJdFZhNJ8Rpp5Y=",
+        "lastModified": 1783564544,
+        "narHash": "sha256-oOgjJXRLkTDfOcgPQpHF7MwIBPOf1pHT77EC/YVfkm4=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "f98908d8b5cacc4c24a6039ffd9f41f6a0de4ba2",
+        "rev": "c624c9c8cffc11dd619a7d37f903556c60d24e9c",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1782811891,
-        "narHash": "sha256-xLfMSeSKKHmYCESe9Ca24eSXUsEV5z1oC59Cqfb7s8U=",
+        "lastModified": 1783566754,
+        "narHash": "sha256-EyVTx67qTNB2utnXRUgOWnaZxV6c07XE2rVCq/qgWxI=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "dc2bfb6686ce41d04185d1a3a11b2b6fc24aeca6",
+        "rev": "4065d7e175fb182a2e30b982b0d8121c97c8d46b",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783142816,
-        "narHash": "sha256-wfuhflRtE2Q+sXLJsobste6uCJdEqr2pHA7RL0NEuEg=",
+        "lastModified": 1783746420,
+        "narHash": "sha256-qoeJtMB9iJS8ew9nhwV4XD6O7YGkdC8S/sFr1B/tTSk=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "0509694d78c99e3065ab3b09c73bf05df460abb7",
+        "rev": "71ab752e1b4ec4d4e86826ef6eba74eabae81117",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783146329,
-        "narHash": "sha256-koldAEI5lE97dQA6GD2/ZqZrpAVXkNy1ojq0YSBwObg=",
+        "lastModified": 1783760469,
+        "narHash": "sha256-xvuI3JYTu6z3C5rQ+88ZEtSH2MOk9JmmlaeU1J5rNI8=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "0cd752bbf6550c53926fee5f2f301828d4847097",
+        "rev": "f5fb93830f8783a07a3248798341675e3bb0b97b",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -575,45 +575,22 @@
           "nix-gaming",
           "flake-compat"
         ],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nix-gaming",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-gaming",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -649,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782704057,
-        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
+        "lastModified": 1783740085,
+        "narHash": "sha256-qajyHfZY29G2oEQk+uHxmsJcRoBUBXP9maTpFlwP/dI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
+        "rev": "3cd22efe6471dc7365c822bd9ad73a21e55f38fb",
         "type": "github"
       },
       "original": {
@@ -919,11 +896,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783123730,
-        "narHash": "sha256-QbTdquZaVN7ZVH4EJgpQTeqrdkwnJrN1TgQJFa3f/tc=",
+        "lastModified": 1783744348,
+        "narHash": "sha256-LE+2A+HUEH1m3TozkyV+ohCCu7I21Y51mM6RisTCbqU=",
         "ref": "refs/heads/main",
-        "rev": "c7d0c5f85ff82a71ef10c27591367708af693c26",
-        "revCount": 137,
+        "rev": "841861b39dc0c4fe36ed2a92289b899fd4d956f2",
+        "revCount": 140,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -956,11 +933,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1781781064,
-        "narHash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
+        "lastModified": 1783522755,
+        "narHash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
+        "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
         "type": "github"
       },
       "original": {
@@ -979,11 +956,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1782850610,
-        "narHash": "sha256-SAl7vyRyLUkt0XtcE2fAs4cWD4fOCZGI3RjBZ5U/yNU=",
+        "lastModified": 1783192860,
+        "narHash": "sha256-gJPZkL4+9LkU3PPxlGOAyTH5vf4W9vLhhODNU1vh3+o=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "7db41f8024ff84cc5ecc532560a5b6598ca65208",
+        "rev": "b3c67abfab626bdd0be226fcf8120eefcae545c8",
         "type": "github"
       },
       "original": {
@@ -999,11 +976,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781772065,
-        "narHash": "sha256-xIbRSwDB1GBAUsWsQZUjudGfAGQt3BOpsWaO/ugVa4w=",
+        "lastModified": 1783744694,
+        "narHash": "sha256-2cp6N3rrwnGYLTx9l6N+NI+kwrCWxvJUbj5WJhvB29A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "adda04f0bf4819575b1978c2f8d78401b3c2be12",
+        "rev": "c3e90c89649b07d1a96e4b9dd6cd0d6e44b91a74",
         "type": "github"
       },
       "original": {
@@ -1059,11 +1036,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1782934759,
-        "narHash": "sha256-1YTEea1x4jfVZkwj2P9K+EpN4huU4PlCsMXbl4ili/A=",
+        "lastModified": 1783739759,
+        "narHash": "sha256-TngG2a3g0gnBAPkR6gM5zwbqFbOc0Y4kioX4N+D7MP4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "a34118c61059e72f9276680400c4f52e8b4db4dd",
+        "rev": "e203d4a2fd19e95d5d81837fd64dd69fd1ad7b12",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1056,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783023993,
-        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
         "type": "github"
       },
       "original": {
@@ -1101,11 +1078,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781749433,
-        "narHash": "sha256-Pb2+bL5WRZLIzb/NMdjHEe9UBcU/yGfb1QWlyzyMTic=",
+        "lastModified": 1783563769,
+        "narHash": "sha256-FGH7qC3qDIyEb/9E3IcLnndKf2gXKGJDmDLcAaCWkL8=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "be97295fa81fe743b9753449143dd4931e51d63c",
+        "rev": "64ba378bd5273663aae10870daf65c955849ccb0",
         "type": "github"
       },
       "original": {
@@ -1116,11 +1093,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783003425,
-        "narHash": "sha256-CLVsEepcFedoiIwXVlAYam9bbTt3mmTJXgGrvoLDDFM=",
+        "lastModified": 1783693695,
+        "narHash": "sha256-ll8SjCNgwWuou5Q64GMjuUrrqRJW1gy3uCMjd+oa9KA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6147971a7160e60cf691651d97cc8411395f5d90",
+        "rev": "dc29ee8fa098c86053cc8ef25594738f28be5b6b",
         "type": "github"
       },
       "original": {
@@ -1162,11 +1139,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1240,11 +1217,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -1352,11 +1329,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -1368,11 +1345,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -1384,11 +1361,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "lastModified": 1782978903,
+        "narHash": "sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "rev": "d33369954a67ae3322177dc9a3d564092912120c",
         "type": "github"
       },
       "original": {
@@ -1400,11 +1377,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1782999065,
-        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
+        "lastModified": 1783703440,
+        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
+        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
         "type": "github"
       },
       "original": {
@@ -1422,11 +1399,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783167752,
-        "narHash": "sha256-2Vq4lZBAWMgKVF+OrDBOf03VdSAYQrViOy2e+4wWE+4=",
+        "lastModified": 1783771036,
+        "narHash": "sha256-P6fvrJPHOu5MedC8CRUsrSBAsyg+J4aNhL7eaJ5EYR8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8e66e7ac0919e2eb3be1711281b1f3154caace4e",
+        "rev": "b3cd94506ad0d8dbaee902fb38579d0bd45fef8e",
         "type": "github"
       },
       "original": {
@@ -1518,11 +1495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781785859,
-        "narHash": "sha256-NKq4Rgkc5LRoAOXxv/HgMA22m3l4YRXjfDBAfxJt9u4=",
+        "lastModified": 1783606376,
+        "narHash": "sha256-C/W5Pkyh816xbrNhIcFvno8LnCQsgGWbTw9q00b5inE=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "9dff917b552fcfe50b5da5f0b6df69a63b507d7d",
+        "rev": "01b95a918e6942154138bbc9d8ec9dc298fb30e6",
         "type": "github"
       },
       "original": {
@@ -1538,11 +1515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782811879,
-        "narHash": "sha256-7YAUrV8YoDFnvOtFAGzdMVgNh25h7nOg3PxjRmLAHaE=",
+        "lastModified": 1783673918,
+        "narHash": "sha256-cFG5vnmjJcZRVCSUaqQLOdwkX6iqF6bY8IvvmBSGSRs=",
         "ref": "master",
-        "rev": "1661ef100a431a470ed2c42e6d06539b77edf826",
-        "revCount": 825,
+        "rev": "4df562dfb2475a9057f0f33a8db75808efad8670",
+        "revCount": 830,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1631,11 +1608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783104586,
-        "narHash": "sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1ebd41717762d837d5115f7108522c29cdb00fbb",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/3a4f4055db5f96ce696b5704c996d5bffbcda58d?narHash=sha256-fQ4%2B88WbgRkQYCMF37GYNuthHojlYhvfIAKJpSynVyk%3D' (2026-07-02)
  → 'github:xddxdd/nix-cachyos-kernel/4673c8f6d48baf2ec3f14b6a9f8c4ecfb0810d6f?narHash=sha256-w5ALD125oHIa5MVhoBXo3qx2ktvRvJ%2B1p8UScV9f8OI%3D' (2026-07-10)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/dc2bfb6686ce41d04185d1a3a11b2b6fc24aeca6?narHash=sha256-xLfMSeSKKHmYCESe9Ca24eSXUsEV5z1oC59Cqfb7s8U%3D' (2026-06-30)
  → 'github:CachyOS/linux-cachyos/4065d7e175fb182a2e30b982b0d8121c97c8d46b?narHash=sha256-EyVTx67qTNB2utnXRUgOWnaZxV6c07XE2rVCq/qgWxI%3D' (2026-07-09)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/f98908d8b5cacc4c24a6039ffd9f41f6a0de4ba2?narHash=sha256-YGYe7cy8vUFguQzdCt6FP1B/viF53cJdFZhNJ8Rpp5Y%3D' (2026-06-30)
  → 'github:CachyOS/kernel-patches/c624c9c8cffc11dd619a7d37f903556c60d24e9c?narHash=sha256-oOgjJXRLkTDfOcgPQpHF7MwIBPOf1pHT77EC/YVfkm4%3D' (2026-07-09)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/6147971a7160e60cf691651d97cc8411395f5d90?narHash=sha256-CLVsEepcFedoiIwXVlAYam9bbTt3mmTJXgGrvoLDDFM%3D' (2026-07-02)
  → 'github:NixOS/nixpkgs/dc29ee8fa098c86053cc8ef25594738f28be5b6b?narHash=sha256-ll8SjCNgwWuou5Q64GMjuUrrqRJW1gy3uCMjd%2Boa9KA%3D' (2026-07-10)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/0509694d78c99e3065ab3b09c73bf05df460abb7?narHash=sha256-wfuhflRtE2Q%2BsXLJsobste6uCJdEqr2pHA7RL0NEuEg%3D' (2026-07-04)
  → 'github:AvengeMedia/DankMaterialShell/71ab752e1b4ec4d4e86826ef6eba74eabae81117?narHash=sha256-qoeJtMB9iJS8ew9nhwV4XD6O7YGkdC8S/sFr1B/tTSk%3D' (2026-07-11)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/0cd752bbf6550c53926fee5f2f301828d4847097?narHash=sha256-koldAEI5lE97dQA6GD2/ZqZrpAVXkNy1ojq0YSBwObg%3D' (2026-07-04)
  → 'github:AvengeMedia/dms-plugin-registry/f5fb93830f8783a07a3248798341675e3bb0b97b?narHash=sha256-xvuI3JYTu6z3C5rQ%2B88ZEtSH2MOk9JmmlaeU1J5rNI8%3D' (2026-07-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/868d0a692de703c2de98fab61968e4e310b7c28e?narHash=sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck%3D' (2026-06-29)
  → 'github:nix-community/home-manager/3cd22efe6471dc7365c822bd9ad73a21e55f38fb?narHash=sha256-qajyHfZY29G2oEQk%2BuHxmsJcRoBUBXP9maTpFlwP/dI%3D' (2026-07-11)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=c7d0c5f85ff82a71ef10c27591367708af693c26' (2026-07-04)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=841861b39dc0c4fe36ed2a92289b899fd4d956f2' (2026-07-11)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/49fc6117fd6c043adaa2ead316b82db5ed735d36?narHash=sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0%3D' (2026-06-18)
  → 'github:YaLTeR/niri/0777769e719b7c9b7c980d4ea66288bfbb4da5b3?narHash=sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE%3D' (2026-07-08)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
  → 'github:nixos/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612?narHash=sha256-iffAls3iaNTyJC2faYcUXSI%2BGp02cDjYl%2BMygxKl2GI%3D' (2026-07-08)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/7db41f8024ff84cc5ecc532560a5b6598ca65208?narHash=sha256-SAl7vyRyLUkt0XtcE2fAs4cWD4fOCZGI3RjBZ5U/yNU%3D' (2026-06-30)
  → 'github:LovingMelody/nix-citizen/b3c67abfab626bdd0be226fcf8120eefcae545c8?narHash=sha256-gJPZkL4%2B9LkU3PPxlGOAyTH5vf4W9vLhhODNU1vh3%2Bo%3D' (2026-07-04)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8?narHash=sha256-oPXCU/SSUokcGaJREHibG1CBX3%2Bs/W7orDWQOZDsEeQ%3D' (2026-06-29)
  → 'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/adda04f0bf4819575b1978c2f8d78401b3c2be12?narHash=sha256-xIbRSwDB1GBAUsWsQZUjudGfAGQt3BOpsWaO/ugVa4w%3D' (2026-06-18)
  → 'github:LnL7/nix-darwin/c3e90c89649b07d1a96e4b9dd6cd0d6e44b91a74?narHash=sha256-2cp6N3rrwnGYLTx9l6N%2BNI%2BkwrCWxvJUbj5WJhvB29A%3D' (2026-07-11)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/a34118c61059e72f9276680400c4f52e8b4db4dd?narHash=sha256-1YTEea1x4jfVZkwj2P9K%2BEpN4huU4PlCsMXbl4ili/A%3D' (2026-07-01)
  → 'github:fufexan/nix-gaming/e203d4a2fd19e95d5d81837fd64dd69fd1ad7b12?narHash=sha256-TngG2a3g0gnBAPkR6gM5zwbqFbOc0Y4kioX4N%2BD7MP4%3D' (2026-07-11)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'nix-gaming/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
• Updated input 'nix-gaming/git-hooks':
    'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
  → 'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
• Removed input 'nix-gaming/git-hooks/gitignore'
• Removed input 'nix-gaming/git-hooks/gitignore/nixpkgs'
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/89570f24e97e614aa34aa9ab1c927b6578a43775?narHash=sha256-EMzXKmnOtBQ2MnvpiNOm7E%2BkOMvdPrIKaeg52Tip2Uk%3D' (2026-06-23)
  → 'github:NixOS/nixpkgs/d33369954a67ae3322177dc9a3d564092912120c?narHash=sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk%3D' (2026-07-02)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074?narHash=sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o%3D' (2026-07-02)
  → 'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c?narHash=sha256-RY8e%2BgR2/DhXsYDxGDL6Hhe9%2BPOD9u4%2BllwxMBqMQDs%3D' (2026-07-07)
• Updated input 'nixpak':
    'github:nixpak/nixpak/be97295fa81fe743b9753449143dd4931e51d63c?narHash=sha256-Pb2%2BbL5WRZLIzb/NMdjHEe9UBcU/yGfb1QWlyzyMTic%3D' (2026-06-18)
  → 'github:nixpak/nixpak/64ba378bd5273663aae10870daf65c955849ccb0?narHash=sha256-FGH7qC3qDIyEb/9E3IcLnndKf2gXKGJDmDLcAaCWkL8%3D' (2026-07-09)
• Updated input 'nixpak/flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/80d591ed473cfc46329932c2aadac9b435342c7c?narHash=sha256-5Dgj5%2BpIQYZKrXUGaLCk7CKfN3MmpwIhO94%2B%2BWVxvng%3D' (2026-07-02)
  → 'github:NixOS/nixpkgs/8f0500b9660505dc3cb647775fe9a978a74b5283?narHash=sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw%3D' (2026-07-10)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
  → 'github:NixOS/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612?narHash=sha256-iffAls3iaNTyJC2faYcUXSI%2BGp02cDjYl%2BMygxKl2GI%3D' (2026-07-08)
• Updated input 'nur':
    'github:nix-community/NUR/8e66e7ac0919e2eb3be1711281b1f3154caace4e?narHash=sha256-2Vq4lZBAWMgKVF%2BOrDBOf03VdSAYQrViOy2e%2B4wWE%2B4%3D' (2026-07-04)
  → 'github:nix-community/NUR/b3cd94506ad0d8dbaee902fb38579d0bd45fef8e?narHash=sha256-P6fvrJPHOu5MedC8CRUsrSBAsyg%2BJ4aNhL7eaJ5EYR8%3D' (2026-07-11)
• Updated input 'paneru':
    'github:karinushka/paneru/9dff917b552fcfe50b5da5f0b6df69a63b507d7d?narHash=sha256-NKq4Rgkc5LRoAOXxv/HgMA22m3l4YRXjfDBAfxJt9u4%3D' (2026-06-18)
  → 'github:karinushka/paneru/01b95a918e6942154138bbc9d8ec9dc298fb30e6?narHash=sha256-C/W5Pkyh816xbrNhIcFvno8LnCQsgGWbTw9q00b5inE%3D' (2026-07-09)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=1661ef100a431a470ed2c42e6d06539b77edf826' (2026-06-30)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4df562dfb2475a9057f0f33a8db75808efad8670' (2026-07-10)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/1ebd41717762d837d5115f7108522c29cdb00fbb?narHash=sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs%3D' (2026-07-03)
  → 'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9?narHash=sha256-aCWC8ngycU7OdJrU2%2BJe3qf%2B1a2ykuBvpPhZT/9tXMc%3D' (2026-07-04)```