### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782721201,
-        "narHash": "sha256-7asJHLsyXrNs5hjPrNjuEtyrmbdxrEtrhWx9+GkoqNU=",
+        "lastModified": 1783915469,
+        "narHash": "sha256-JP7Rcwf+3n6IouuGw3VwhUGLpmEo6ou04nLVWZW5TLo=",
         "owner": "saatvik333",
         "repo": "wayland-bongocat",
-        "rev": "e46f7f5c2cff192a9884de7eeda946292abb0d2c",
+        "rev": "9cd36c6b79d9271810054fb4e99793934bbae98b",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783710455,
-        "narHash": "sha256-w5ALD125oHIa5MVhoBXo3qx2ktvRvJ+1p8UScV9f8OI=",
+        "lastModified": 1783794640,
+        "narHash": "sha256-SgzzS5GtMFv323ritWP8A3rwhjphB7AYTfHLNSXGX3c=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "4673c8f6d48baf2ec3f14b6a9f8c4ecfb0810d6f",
+        "rev": "6472f543b68e0b874603ad944419747815cfeb7a",
         "type": "github"
       },
       "original": {
@@ -147,22 +147,39 @@
     },
     "dank-material-shell": {
       "inputs": {
+        "dank-qml-common": "dank-qml-common",
         "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1783746420,
-        "narHash": "sha256-qoeJtMB9iJS8ew9nhwV4XD6O7YGkdC8S/sFr1B/tTSk=",
+        "lastModified": 1784389941,
+        "narHash": "sha256-1Hr6izy4O2DoHu1a0C0y79uTUQWWW2vmLXZTHBXw6Nc=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "71ab752e1b4ec4d4e86826ef6eba74eabae81117",
+        "rev": "4a90bd3fb154b1aa5ef592130a58c93c9c49bfa0",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
+        "type": "github"
+      }
+    },
+    "dank-qml-common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784386873,
+        "narHash": "sha256-n0LKLirPnNSXYxElK1IpnybEwU0nnyso4kpsEFX88U0=",
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "rev": "4fa313766ab5cd2766be0f87a163305ca9af6faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
         "type": "github"
       }
     },
@@ -193,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783760469,
-        "narHash": "sha256-xvuI3JYTu6z3C5rQ+88ZEtSH2MOk9JmmlaeU1J5rNI8=",
+        "lastModified": 1784341230,
+        "narHash": "sha256-2QxkI52zrEdPPAlE5R71lqBeZxXuHwGAYl3ILCFtTjo=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "f5fb93830f8783a07a3248798341675e3bb0b97b",
+        "rev": "1463198cb6d23211ee45cc6fe21acc75aa4e77b8",
         "type": "github"
       },
       "original": {
@@ -326,11 +343,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1781217157,
-        "narHash": "sha256-N3q/SP2Ropk336e9KSgLh7kpROY6P70dprYdbPIfd5c=",
+        "lastModified": 1784255282,
+        "narHash": "sha256-srM+PTqxfyvbQ0BevsOtP8vQv/Ox6OMtY4DktoDxLKg=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "ce63eaf7ebfe04a176653f66385a7f0a36380cee",
+        "rev": "66ddd2f69a5c4677f0095c6f70eea1217dc45749",
         "type": "github"
       },
       "original": {
@@ -626,11 +643,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783740085,
-        "narHash": "sha256-qajyHfZY29G2oEQk+uHxmsJcRoBUBXP9maTpFlwP/dI=",
+        "lastModified": 1784350909,
+        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3cd22efe6471dc7365c822bd9ad73a21e55f38fb",
+        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
         "type": "github"
       },
       "original": {
@@ -677,11 +694,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1778781969,
-        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
+        "lastModified": 1784254960,
+        "narHash": "sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
+        "rev": "4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69",
         "type": "github"
       },
       "original": {
@@ -896,11 +913,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783744348,
-        "narHash": "sha256-LE+2A+HUEH1m3TozkyV+ohCCu7I21Y51mM6RisTCbqU=",
+        "lastModified": 1784320426,
+        "narHash": "sha256-LEwF60zKoIAHmM12ryTQ17+/e73+fs2IHyxcj9J3gu4=",
         "ref": "refs/heads/main",
-        "rev": "841861b39dc0c4fe36ed2a92289b899fd4d956f2",
-        "revCount": 140,
+        "rev": "e931c61ea715fec54e2343e850b4811cc6296fbb",
+        "revCount": 143,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -956,11 +973,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1783192860,
-        "narHash": "sha256-gJPZkL4+9LkU3PPxlGOAyTH5vf4W9vLhhODNU1vh3+o=",
+        "lastModified": 1783846619,
+        "narHash": "sha256-gBMBIIu7ryLislbx43K2jtiT37A3un3+8FJNIqZsxnY=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "b3c67abfab626bdd0be226fcf8120eefcae545c8",
+        "rev": "e9454141594a236baff2aa7da10ac0a330f8c5a6",
         "type": "github"
       },
       "original": {
@@ -1036,11 +1053,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1783739759,
-        "narHash": "sha256-TngG2a3g0gnBAPkR6gM5zwbqFbOc0Y4kioX4N+D7MP4=",
+        "lastModified": 1784343184,
+        "narHash": "sha256-xD2Fxgh6jD0m3v3ijO9+59EFlYIwIlnw8Z/yQpsAukA=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "e203d4a2fd19e95d5d81837fd64dd69fd1ad7b12",
+        "rev": "ddadbf248cacdd057658d30bd079e589e7c2b750",
         "type": "github"
       },
       "original": {
@@ -1056,11 +1073,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783414108,
-        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1095,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783563769,
-        "narHash": "sha256-FGH7qC3qDIyEb/9E3IcLnndKf2gXKGJDmDLcAaCWkL8=",
+        "lastModified": 1784059782,
+        "narHash": "sha256-uIMxTemoRKv+qdP9OExl9wbfr5+JE6VcSESOeEVV2Ps=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "64ba378bd5273663aae10870daf65c955849ccb0",
+        "rev": "a6e7b272a4483d14f5c057a9b5c0d19f15b401e5",
         "type": "github"
       },
       "original": {
@@ -1093,11 +1110,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783693695,
-        "narHash": "sha256-ll8SjCNgwWuou5Q64GMjuUrrqRJW1gy3uCMjd+oa9KA=",
+        "lastModified": 1783760736,
+        "narHash": "sha256-PEXS6z/zIvH+O7J3Ua3N2OUE7IvMhhghwtKxZhVfm5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc29ee8fa098c86053cc8ef25594738f28be5b6b",
+        "rev": "bbb4df715cb62e53cd329090c2b69eb07f2bddac",
         "type": "github"
       },
       "original": {
@@ -1217,11 +1234,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -1329,11 +1346,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -1345,11 +1362,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -1361,11 +1378,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782978903,
-        "narHash": "sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk=",
+        "lastModified": 1783791668,
+        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d33369954a67ae3322177dc9a3d564092912120c",
+        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
         "type": "github"
       },
       "original": {
@@ -1377,11 +1394,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
@@ -1399,11 +1416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783771036,
-        "narHash": "sha256-P6fvrJPHOu5MedC8CRUsrSBAsyg+J4aNhL7eaJ5EYR8=",
+        "lastModified": 1784393194,
+        "narHash": "sha256-0+0e5xQn8iNYoMoFQ4wlC5DuwPQASXSWrw+UxytbAqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b3cd94506ad0d8dbaee902fb38579d0bd45fef8e",
+        "rev": "114761d48b1aaff4daff741e365a7832cf280931",
         "type": "github"
       },
       "original": {
@@ -1495,11 +1512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783606376,
-        "narHash": "sha256-C/W5Pkyh816xbrNhIcFvno8LnCQsgGWbTw9q00b5inE=",
+        "lastModified": 1784145133,
+        "narHash": "sha256-eZR9nG+25hpA6vIZgF37Pts0bPYCV3tJpp/B+nrijOU=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "01b95a918e6942154138bbc9d8ec9dc298fb30e6",
+        "rev": "e5cf00809a233d5ec17ad2f7ea9c8866a014cdc3",
         "type": "github"
       },
       "original": {
@@ -1852,11 +1869,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226823,
-        "narHash": "sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi+sc=",
+        "lastModified": 1783895132,
+        "narHash": "sha256-Dl0Gvrig3EpE962hzF3ETPhUztlfuRhcmlpd8ioHN54=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "8575d0ef55d70f9b4c46b6bffb3accf912217e1e",
+        "rev": "a2b5c635d8c8c99b286967658d0d177044887eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'bongocat':
    'github:saatvik333/wayland-bongocat/e46f7f5c2cff192a9884de7eeda946292abb0d2c?narHash=sha256-7asJHLsyXrNs5hjPrNjuEtyrmbdxrEtrhWx9%2BGkoqNU%3D' (2026-06-29)
  → 'github:saatvik333/wayland-bongocat/9cd36c6b79d9271810054fb4e99793934bbae98b?narHash=sha256-JP7Rcwf%2B3n6IouuGw3VwhUGLpmEo6ou04nLVWZW5TLo%3D' (2026-07-13)
• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/4673c8f6d48baf2ec3f14b6a9f8c4ecfb0810d6f?narHash=sha256-w5ALD125oHIa5MVhoBXo3qx2ktvRvJ%2B1p8UScV9f8OI%3D' (2026-07-10)
  → 'github:xddxdd/nix-cachyos-kernel/6472f543b68e0b874603ad944419747815cfeb7a?narHash=sha256-SgzzS5GtMFv323ritWP8A3rwhjphB7AYTfHLNSXGX3c%3D' (2026-07-11)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/dc29ee8fa098c86053cc8ef25594738f28be5b6b?narHash=sha256-ll8SjCNgwWuou5Q64GMjuUrrqRJW1gy3uCMjd%2Boa9KA%3D' (2026-07-10)
  → 'github:NixOS/nixpkgs/bbb4df715cb62e53cd329090c2b69eb07f2bddac?narHash=sha256-PEXS6z/zIvH%2BO7J3Ua3N2OUE7IvMhhghwtKxZhVfm5U%3D' (2026-07-11)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/71ab752e1b4ec4d4e86826ef6eba74eabae81117?narHash=sha256-qoeJtMB9iJS8ew9nhwV4XD6O7YGkdC8S/sFr1B/tTSk%3D' (2026-07-11)
  → 'github:AvengeMedia/DankMaterialShell/5dfd875b9ec012a15a6c986be25e6552659dd7fb?narHash=sha256-VgXCn1CntFGbQZwAwhoVTB3cBfuVln2u0SfaXDkyQoQ%3D' (2026-07-18)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/f5fb93830f8783a07a3248798341675e3bb0b97b?narHash=sha256-xvuI3JYTu6z3C5rQ%2B88ZEtSH2MOk9JmmlaeU1J5rNI8%3D' (2026-07-11)
  → 'github:AvengeMedia/dms-plugin-registry/1463198cb6d23211ee45cc6fe21acc75aa4e77b8?narHash=sha256-2QxkI52zrEdPPAlE5R71lqBeZxXuHwGAYl3ILCFtTjo%3D' (2026-07-18)
• Updated input 'flake-file':
    'github:vic/flake-file/ce63eaf7ebfe04a176653f66385a7f0a36380cee?narHash=sha256-N3q/SP2Ropk336e9KSgLh7kpROY6P70dprYdbPIfd5c%3D' (2026-06-11)
  → 'github:vic/flake-file/66ddd2f69a5c4677f0095c6f70eea1217dc45749?narHash=sha256-srM%2BPTqxfyvbQ0BevsOtP8vQv/Ox6OMtY4DktoDxLKg%3D' (2026-07-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3cd22efe6471dc7365c822bd9ad73a21e55f38fb?narHash=sha256-qajyHfZY29G2oEQk%2BuHxmsJcRoBUBXP9maTpFlwP/dI%3D' (2026-07-11)
  → 'github:nix-community/home-manager/4ce190229c73d44536caa7072f6308fb2d8feeb3?narHash=sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE%2BKzCrM%3D' (2026-07-18)
• Updated input 'import-tree':
    'github:vic/import-tree/d321337efd0f23a9eb14a42adb7b2c29313ab274?narHash=sha256-Jjuz5CmSkur8KvLDoGa%2BvylEp%2BRkQtv4mt/qcMznpH0%3D' (2026-05-14)
  → 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69?narHash=sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8%3D' (2026-07-17)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=841861b39dc0c4fe36ed2a92289b899fd4d956f2' (2026-07-11)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=e931c61ea715fec54e2343e850b4811cc6296fbb' (2026-07-17)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612?narHash=sha256-iffAls3iaNTyJC2faYcUXSI%2BGp02cDjYl%2BMygxKl2GI%3D' (2026-07-08)
  → 'github:nixos/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46?narHash=sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k%3D' (2026-07-15)
• Updated input 'niri-nix/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/8575d0ef55d70f9b4c46b6bffb3accf912217e1e?narHash=sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi%2Bsc%3D' (2026-06-12)
  → 'github:Supreeeme/xwayland-satellite/a2b5c635d8c8c99b286967658d0d177044887eb8?narHash=sha256-Dl0Gvrig3EpE962hzF3ETPhUztlfuRhcmlpd8ioHN54%3D' (2026-07-12)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/b3c67abfab626bdd0be226fcf8120eefcae545c8?narHash=sha256-gJPZkL4%2B9LkU3PPxlGOAyTH5vf4W9vLhhODNU1vh3%2Bo%3D' (2026-07-04)
  → 'github:LovingMelody/nix-citizen/e9454141594a236baff2aa7da10ac0a330f8c5a6?narHash=sha256-gBMBIIu7ryLislbx43K2jtiT37A3un3%2B8FJNIqZsxnY%3D' (2026-07-12)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/65179426c83bb3f6bc14898b42ea1c6f01d374b0?narHash=sha256-xnJJk%2Bct%2BD2%2BwdRxj1wk36w5zV9RVESwRqcklPdt3fM%3D' (2026-07-02)
  → 'github:NixOS/nixpkgs/e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3?narHash=sha256-UgCQzxeWI75XM8G%2BhPrPh%2BMKzEPjG3SpAj7dtqSbksA%3D' (2026-07-11)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/e203d4a2fd19e95d5d81837fd64dd69fd1ad7b12?narHash=sha256-TngG2a3g0gnBAPkR6gM5zwbqFbOc0Y4kioX4N%2BD7MP4%3D' (2026-07-11)
  → 'github:fufexan/nix-gaming/ddadbf248cacdd057658d30bd079e589e7c2b750?narHash=sha256-xD2Fxgh6jD0m3v3ijO9%2B59EFlYIwIlnw8Z/yQpsAukA%3D' (2026-07-18)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/d33369954a67ae3322177dc9a3d564092912120c?narHash=sha256-bG1LAS3YehMzp4RSXw99o3yMEO/Ktb0Tx29RCtEU0Tk%3D' (2026-07-02)
  → 'github:NixOS/nixpkgs/716c7a2664ca8325617b8a7fbb609273f2c4cae7?narHash=sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA%3D' (2026-07-11)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c?narHash=sha256-RY8e%2BgR2/DhXsYDxGDL6Hhe9%2BPOD9u4%2BllwxMBqMQDs%3D' (2026-07-07)
  → 'github:nix-community/nix-index-database/1111b9bc836afb7e31a7014e8d1272de9b1c917d?narHash=sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj%2BdNn/8Dsi3sPM%3D' (2026-07-12)
• Updated input 'nixpak':
    'github:nixpak/nixpak/64ba378bd5273663aae10870daf65c955849ccb0?narHash=sha256-FGH7qC3qDIyEb/9E3IcLnndKf2gXKGJDmDLcAaCWkL8%3D' (2026-07-09)
  → 'github:nixpak/nixpak/a6e7b272a4483d14f5c057a9b5c0d19f15b401e5?narHash=sha256-uIMxTemoRKv%2BqdP9OExl9wbfr5%2BJE6VcSESOeEVV2Ps%3D' (2026-07-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/8f0500b9660505dc3cb647775fe9a978a74b5283?narHash=sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw%3D' (2026-07-10)
  → 'github:NixOS/nixpkgs/293d6abedf0478e681a4dfcfcb35b30fc796a32f?narHash=sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0%3D' (2026-07-17)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612?narHash=sha256-iffAls3iaNTyJC2faYcUXSI%2BGp02cDjYl%2BMygxKl2GI%3D' (2026-07-08)
  → 'github:NixOS/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46?narHash=sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k%3D' (2026-07-15)
• Updated input 'nur':
    'github:nix-community/NUR/b3cd94506ad0d8dbaee902fb38579d0bd45fef8e?narHash=sha256-P6fvrJPHOu5MedC8CRUsrSBAsyg%2BJ4aNhL7eaJ5EYR8%3D' (2026-07-11)
  → 'github:nix-community/NUR/2c26f5cbddc21f366551ff205ee4624976f70f42?narHash=sha256-daSZO%2B6Qi5hJbPuojZdlbgkhFhtj6gy3ZXXyqxB0w9c%3D' (2026-07-18)
• Updated input 'paneru':
    'github:karinushka/paneru/01b95a918e6942154138bbc9d8ec9dc298fb30e6?narHash=sha256-C/W5Pkyh816xbrNhIcFvno8LnCQsgGWbTw9q00b5inE%3D' (2026-07-09)
  → 'github:karinushka/paneru/e5cf00809a233d5ec17ad2f7ea9c8866a014cdc3?narHash=sha256-eZR9nG%2B25hpA6vIZgF37Pts0bPYCV3tJpp/B%2BnrijOU%3D' (2026-07-15)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4df562dfb2475a9057f0f33a8db75808efad8670' (2026-07-10)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4df562dfb2475a9057f0f33a8db75808efad8670' (2026-07-10)```