### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783794640,
-        "narHash": "sha256-SgzzS5GtMFv323ritWP8A3rwhjphB7AYTfHLNSXGX3c=",
+        "lastModified": 1784919871,
+        "narHash": "sha256-pCtk2K7SXa43Ujj2mav4L40OHqqymXt+y9YKGvm7AzY=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "6472f543b68e0b874603ad944419747815cfeb7a",
+        "rev": "29893f428702736575d4eb5806c26c3148d6da8c",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "cachyos-kernel-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1783564544,
-        "narHash": "sha256-oOgjJXRLkTDfOcgPQpHF7MwIBPOf1pHT77EC/YVfkm4=",
+        "lastModified": 1783974915,
+        "narHash": "sha256-kReDG2emoGxaG0Lr8tt9jUuu1kQu07yAJZhVWfbwxYc=",
         "owner": "CachyOS",
         "repo": "kernel-patches",
-        "rev": "c624c9c8cffc11dd619a7d37f903556c60d24e9c",
+        "rev": "ea739d734ec179864b21446856315bc49f7c52fa",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     "cachyos-kernel_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1783566754,
-        "narHash": "sha256-EyVTx67qTNB2utnXRUgOWnaZxV6c07XE2rVCq/qgWxI=",
+        "lastModified": 1784569577,
+        "narHash": "sha256-pmwdKRPSavZ98QJv/Xlbj2U60AZ/+P4aevLBZ71jDaA=",
         "owner": "CachyOS",
         "repo": "linux-cachyos",
-        "rev": "4065d7e175fb182a2e30b982b0d8121c97c8d46b",
+        "rev": "5ca2493c51b1cadec102c9c549345b43f669960b",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784389941,
-        "narHash": "sha256-1Hr6izy4O2DoHu1a0C0y79uTUQWWW2vmLXZTHBXw6Nc=",
+        "lastModified": 1784936204,
+        "narHash": "sha256-XNbDvIaPzqqIpgJynqSADAj7Yf8KlGJTo5S/fQJUBxs=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "4a90bd3fb154b1aa5ef592130a58c93c9c49bfa0",
+        "rev": "8bb7396362357650a80dcc8d81407095c91c7dcf",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
     "dank-qml-common": {
       "flake": false,
       "locked": {
-        "lastModified": 1784386873,
-        "narHash": "sha256-n0LKLirPnNSXYxElK1IpnybEwU0nnyso4kpsEFX88U0=",
+        "lastModified": 1784935106,
+        "narHash": "sha256-aVgOBRynme6XNKYCZlf/oCjPDZFwddyUQPRRkEupC3c=",
         "owner": "AvengeMedia",
         "repo": "dank-qml-common",
-        "rev": "4fa313766ab5cd2766be0f87a163305ca9af6faf",
+        "rev": "a172b39841d8f42bac46ac133b76cade1fae91b4",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784341230,
-        "narHash": "sha256-2QxkI52zrEdPPAlE5R71lqBeZxXuHwGAYl3ILCFtTjo=",
+        "lastModified": 1784857968,
+        "narHash": "sha256-83haLQzxrk6sCX76iQlloHWQ+TD0RKsK+LdVTMikNwk=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "1463198cb6d23211ee45cc6fe21acc75aa4e77b8",
+        "rev": "78d478f34ad6790faea447c37d16bab63e1d3570",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -913,11 +913,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784320426,
-        "narHash": "sha256-LEwF60zKoIAHmM12ryTQ17+/e73+fs2IHyxcj9J3gu4=",
+        "lastModified": 1784938247,
+        "narHash": "sha256-yO+L8iSAjvDA6gm+9Jmr+pLt9FkGU5j5mT1DdFpz9Wk=",
         "ref": "refs/heads/main",
-        "rev": "e931c61ea715fec54e2343e850b4811cc6296fbb",
-        "revCount": 143,
+        "rev": "baa586fdd74462f853e478cd3f2c60c57cbd08ae",
+        "revCount": 147,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -950,11 +950,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1783522755,
-        "narHash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
+        "lastModified": 1784570726,
+        "narHash": "sha256-9EMn69JBcFWFgUM7f0VBAX+jBby5b9H3M59U75+5yI4=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
+        "rev": "7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc",
         "type": "github"
       },
       "original": {
@@ -1053,11 +1053,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1784343184,
-        "narHash": "sha256-xD2Fxgh6jD0m3v3ijO9+59EFlYIwIlnw8Z/yQpsAukA=",
+        "lastModified": 1784949315,
+        "narHash": "sha256-DFb7pfxvQIzfj/UiET+jNesON0nt3+5pk11URu+Nqrc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "ddadbf248cacdd057658d30bd079e589e7c2b750",
+        "rev": "a3391389b07fc616f6cc301005013f64f9d4e7e3",
         "type": "github"
       },
       "original": {
@@ -1073,11 +1073,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783864904,
-        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
+        "lastModified": 1784440659,
+        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
+        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
         "type": "github"
       },
       "original": {
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783760736,
-        "narHash": "sha256-PEXS6z/zIvH+O7J3Ua3N2OUE7IvMhhghwtKxZhVfm5U=",
+        "lastModified": 1784900848,
+        "narHash": "sha256-qHfivN3D0K3wKjKCJVhzFBz6eKIt56DHJUvIzbRc5Gc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bbb4df715cb62e53cd329090c2b69eb07f2bddac",
+        "rev": "6136e0cb87c2b1dea66de7caf58fd70db4d78267",
         "type": "github"
       },
       "original": {
@@ -1234,11 +1234,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -1346,11 +1346,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1784120854,
-        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -1378,11 +1378,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1783791668,
-        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {
@@ -1394,11 +1394,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1784280462,
-        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {
@@ -1416,11 +1416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784393194,
-        "narHash": "sha256-0+0e5xQn8iNYoMoFQ4wlC5DuwPQASXSWrw+UxytbAqE=",
+        "lastModified": 1784980806,
+        "narHash": "sha256-jAK2tkBCDVk+OOcv0Mugou+OWDOyfvYfvg1lrekse1o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "114761d48b1aaff4daff741e365a7832cf280931",
+        "rev": "c72673e2d78fd5fcf7d311f17e4f7cb70858872d",
         "type": "github"
       },
       "original": {
@@ -1512,11 +1512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784145133,
-        "narHash": "sha256-eZR9nG+25hpA6vIZgF37Pts0bPYCV3tJpp/B+nrijOU=",
+        "lastModified": 1784896537,
+        "narHash": "sha256-TuVxm2b3crbGs8qDNhQFQ+Yn93usHQN6wVNo42DsQG4=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "e5cf00809a233d5ec17ad2f7ea9c8866a014cdc3",
+        "rev": "68a03e5a65cd2d4242a8220ba8dbed0e04a9c2ee",
         "type": "github"
       },
       "original": {
@@ -1547,11 +1547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783673918,
-        "narHash": "sha256-cFG5vnmjJcZRVCSUaqQLOdwkX6iqF6bY8IvvmBSGSRs=",
+        "lastModified": 1784799776,
+        "narHash": "sha256-6AM0doj8hSNav9qkX4dOHOp1LSjegdQ+VmzDz9MnWAs=",
         "ref": "master",
-        "rev": "4df562dfb2475a9057f0f33a8db75808efad8670",
-        "revCount": 830,
+        "rev": "10b439fc6e3fd65c15fe1c486271b31da05ed023",
+        "revCount": 833,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1885,11 +1885,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1783895132,
-        "narHash": "sha256-Dl0Gvrig3EpE962hzF3ETPhUztlfuRhcmlpd8ioHN54=",
+        "lastModified": 1784679892,
+        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "a2b5c635d8c8c99b286967658d0d177044887eb8",
+        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -145,9 +145,30 @@
         "type": "github"
       }
     },
-    "dank-material-shell": {
+    "dank-greeter": {
       "inputs": {
         "dank-qml-common": "dank-qml-common",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784907716,
+        "narHash": "sha256-Ut8XgrSfgDi5QO71SZxVpjibIZa08dJnNdzm0PWtTxc=",
+        "owner": "AvengeMedia",
+        "repo": "dank-greeter",
+        "rev": "d3c919158e135e2f64e5ad3b025887e3a8b3549f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-greeter",
+        "type": "github"
+      }
+    },
+    "dank-material-shell": {
+      "inputs": {
+        "dank-qml-common": "dank-qml-common_2",
         "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
@@ -168,6 +189,22 @@
       }
     },
     "dank-qml-common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784433462,
+        "narHash": "sha256-8MdKtu/tSYrCenhtmgYW+lcv9JhGPTE3BnSE6WuqO1U=",
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "rev": "8d36f668d73e7a4391ea9ead3939c5de137aa1f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "type": "github"
+      }
+    },
+    "dank-qml-common_2": {
       "flake": false,
       "locked": {
         "lastModified": 1784935106,
@@ -1565,6 +1602,7 @@
       "inputs": {
         "bongocat": "bongocat",
         "cachyos-kernel": "cachyos-kernel",
+        "dank-greeter": "dank-greeter",
         "dank-material-shell": "dank-material-shell",
         "disko": "disko",
         "dms-plugin-registry": "dms-plugin-registry",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
+    dank-greeter = {
+      url = "github:AvengeMedia/dank-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     dank-material-shell = {
       url = "github:AvengeMedia/DankMaterialShell";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/surfaces/lib/greeter/dankmaterialshell.nix
+++ b/modules/surfaces/lib/greeter/dankmaterialshell.nix
@@ -3,6 +3,13 @@
   self,
   ...
 }: {
+  flake-file.inputs = {
+    dank-greeter = {
+      url = "github:AvengeMedia/dank-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
   flake.modules.nixos.dankmaterialshell-greeter = {
     config,
     lib,
@@ -30,12 +37,12 @@
     imports = [
       self.modules.nixos.greeter
       self.modules.nixos.primary-user
-      inputs.dank-material-shell.nixosModules.greeter
+      inputs.dank-greeter.nixosModules.default
     ];
 
     internal.boot.impermanence.extraDirectories = ["/var/lib/dms-greeter"];
 
-    programs.dank-material-shell.greeter = {
+    programs.dms-greeter = {
       enable = true;
       quickshell.package = pkgs.inputs.quickshell.default;
 


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/6472f543b68e0b874603ad944419747815cfeb7a?narHash=sha256-SgzzS5GtMFv323ritWP8A3rwhjphB7AYTfHLNSXGX3c%3D' (2026-07-11)
  → 'github:xddxdd/nix-cachyos-kernel/29893f428702736575d4eb5806c26c3148d6da8c?narHash=sha256-pCtk2K7SXa43Ujj2mav4L40OHqqymXt%2By9YKGvm7AzY%3D' (2026-07-24)
• Updated input 'cachyos-kernel/cachyos-kernel':
    'github:CachyOS/linux-cachyos/4065d7e175fb182a2e30b982b0d8121c97c8d46b?narHash=sha256-EyVTx67qTNB2utnXRUgOWnaZxV6c07XE2rVCq/qgWxI%3D' (2026-07-09)
  → 'github:CachyOS/linux-cachyos/5ca2493c51b1cadec102c9c549345b43f669960b?narHash=sha256-pmwdKRPSavZ98QJv/Xlbj2U60AZ/%2BP4aevLBZ71jDaA%3D' (2026-07-20)
• Updated input 'cachyos-kernel/cachyos-kernel-patches':
    'github:CachyOS/kernel-patches/c624c9c8cffc11dd619a7d37f903556c60d24e9c?narHash=sha256-oOgjJXRLkTDfOcgPQpHF7MwIBPOf1pHT77EC/YVfkm4%3D' (2026-07-09)
  → 'github:CachyOS/kernel-patches/ea739d734ec179864b21446856315bc49f7c52fa?narHash=sha256-kReDG2emoGxaG0Lr8tt9jUuu1kQu07yAJZhVWfbwxYc%3D' (2026-07-13)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/bbb4df715cb62e53cd329090c2b69eb07f2bddac?narHash=sha256-PEXS6z/zIvH%2BO7J3Ua3N2OUE7IvMhhghwtKxZhVfm5U%3D' (2026-07-11)
  → 'github:NixOS/nixpkgs/6136e0cb87c2b1dea66de7caf58fd70db4d78267?narHash=sha256-qHfivN3D0K3wKjKCJVhzFBz6eKIt56DHJUvIzbRc5Gc%3D' (2026-07-24)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/4a90bd3fb154b1aa5ef592130a58c93c9c49bfa0?narHash=sha256-1Hr6izy4O2DoHu1a0C0y79uTUQWWW2vmLXZTHBXw6Nc%3D' (2026-07-18)
  → 'github:AvengeMedia/DankMaterialShell/8bb7396362357650a80dcc8d81407095c91c7dcf?narHash=sha256-XNbDvIaPzqqIpgJynqSADAj7Yf8KlGJTo5S/fQJUBxs%3D' (2026-07-24)
• Updated input 'dank-material-shell/dank-qml-common':
    'github:AvengeMedia/dank-qml-common/4fa313766ab5cd2766be0f87a163305ca9af6faf?narHash=sha256-n0LKLirPnNSXYxElK1IpnybEwU0nnyso4kpsEFX88U0%3D' (2026-07-18)
  → 'github:AvengeMedia/dank-qml-common/a172b39841d8f42bac46ac133b76cade1fae91b4?narHash=sha256-aVgOBRynme6XNKYCZlf/oCjPDZFwddyUQPRRkEupC3c%3D' (2026-07-24)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/1463198cb6d23211ee45cc6fe21acc75aa4e77b8?narHash=sha256-2QxkI52zrEdPPAlE5R71lqBeZxXuHwGAYl3ILCFtTjo%3D' (2026-07-18)
  → 'github:AvengeMedia/dms-plugin-registry/78d478f34ad6790faea447c37d16bab63e1d3570?narHash=sha256-83haLQzxrk6sCX76iQlloHWQ%2BTD0RKsK%2BLdVTMikNwk%3D' (2026-07-24)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=e931c61ea715fec54e2343e850b4811cc6296fbb' (2026-07-17)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=baa586fdd74462f853e478cd3f2c60c57cbd08ae' (2026-07-25)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/0777769e719b7c9b7c980d4ea66288bfbb4da5b3?narHash=sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE%3D' (2026-07-08)
  → 'github:YaLTeR/niri/7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc?narHash=sha256-9EMn69JBcFWFgUM7f0VBAX%2BjBby5b9H3M59U75%2B5yI4%3D' (2026-07-20)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46?narHash=sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k%3D' (2026-07-15)
  → 'github:nixos/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
• Updated input 'niri-nix/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/a2b5c635d8c8c99b286967658d0d177044887eb8?narHash=sha256-Dl0Gvrig3EpE962hzF3ETPhUztlfuRhcmlpd8ioHN54%3D' (2026-07-12)
  → 'github:Supreeeme/xwayland-satellite/8d135d3b2854b30fd01ea6cd6c27e523dd50a839?narHash=sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk%3D' (2026-07-22)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/ddadbf248cacdd057658d30bd079e589e7c2b750?narHash=sha256-xD2Fxgh6jD0m3v3ijO9%2B59EFlYIwIlnw8Z/yQpsAukA%3D' (2026-07-18)
  → 'github:fufexan/nix-gaming/a3391389b07fc616f6cc301005013f64f9d4e7e3?narHash=sha256-DFb7pfxvQIzfj/UiET%2BjNesON0nt3%2B5pk11URu%2BNqrc%3D' (2026-07-25)
• Updated input 'nix-gaming/git-hooks':
    'github:cachix/git-hooks.nix/bca82caa46d5ec0f5d422c61fb1e30bc51313cbe?narHash=sha256-jGiy6%2BsxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ%3D' (2026-07-02)
  → 'github:cachix/git-hooks.nix/43b3c1ab9d40fb1dbb008f451988a91e375825e9?narHash=sha256-ReRHaLgr/uVqdD8afFSn%2BmyXIfpHeOhP0yYe0TJqAA8%3D' (2026-07-17)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/716c7a2664ca8325617b8a7fbb609273f2c4cae7?narHash=sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA%3D' (2026-07-11)
  → 'github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957?narHash=sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY%3D' (2026-07-18)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1111b9bc836afb7e31a7014e8d1272de9b1c917d?narHash=sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj%2BdNn/8Dsi3sPM%3D' (2026-07-12)
  → 'github:nix-community/nix-index-database/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb?narHash=sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4%3D' (2026-07-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/293d6abedf0478e681a4dfcfcb35b30fc796a32f?narHash=sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0%3D' (2026-07-17)
  → 'github:NixOS/nixpkgs/597283ad8aa0b331c788e97c4c262d58877074ef?narHash=sha256-J%2BBx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A%3D' (2026-07-24)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/61b7c44c4073f0b827768aff0049561b5110ea5a?narHash=sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84%3D' (2026-07-18)
  → 'github:NixOS/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
• Updated input 'nur':
    'github:nix-community/NUR/114761d48b1aaff4daff741e365a7832cf280931?narHash=sha256-0%2B0e5xQn8iNYoMoFQ4wlC5DuwPQASXSWrw%2BUxytbAqE%3D' (2026-07-18)
  → 'github:nix-community/NUR/c72673e2d78fd5fcf7d311f17e4f7cb70858872d?narHash=sha256-jAK2tkBCDVk%2BOOcv0Mugou%2BOWDOyfvYfvg1lrekse1o%3D' (2026-07-25)
• Updated input 'paneru':
    'github:karinushka/paneru/e5cf00809a233d5ec17ad2f7ea9c8866a014cdc3?narHash=sha256-eZR9nG%2B25hpA6vIZgF37Pts0bPYCV3tJpp/B%2BnrijOU%3D' (2026-07-15)
  → 'github:karinushka/paneru/68a03e5a65cd2d4242a8220ba8dbed0e04a9c2ee?narHash=sha256-TuVxm2b3crbGs8qDNhQFQ%2BYn93usHQN6wVNo42DsQG4%3D' (2026-07-24)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=4df562dfb2475a9057f0f33a8db75808efad8670' (2026-07-10)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=10b439fc6e3fd65c15fe1c486271b31da05ed023' (2026-07-23)```