### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,56 +39,22 @@
     },
     "cachyos-kernel": {
       "inputs": {
-        "cachyos-kernel": "cachyos-kernel_2",
-        "cachyos-kernel-patches": "cachyos-kernel-patches",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785004507,
-        "narHash": "sha256-z6uYlDlOqJOl4vfOr5jGeF90UR90hhQrRsAOtSqSq7g=",
+        "lastModified": 1785524300,
+        "narHash": "sha256-QeJMNuRgY5E7pAYTjgMO8Te9Rg0AEI5CgS8EYQpZzHw=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "6669b7b5f6b468e2be07711fe65d9e6c30560975",
+        "rev": "4f3c8ca048091c5fbad5447c660133ac1a151ac7",
         "type": "github"
       },
       "original": {
         "owner": "xddxdd",
         "ref": "release",
         "repo": "nix-cachyos-kernel",
-        "type": "github"
-      }
-    },
-    "cachyos-kernel-patches": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1785003520,
-        "narHash": "sha256-wArbhgKHjF1oJOzFVaHlz5rTxKPreb7ezbGbwQXTXJg=",
-        "owner": "CachyOS",
-        "repo": "kernel-patches",
-        "rev": "0fbc4adfec58c056d07adfc78d0e09bd32162853",
-        "type": "github"
-      },
-      "original": {
-        "owner": "CachyOS",
-        "repo": "kernel-patches",
-        "type": "github"
-      }
-    },
-    "cachyos-kernel_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1785001338,
-        "narHash": "sha256-iX0iia6K1Z8k5ptg9zW/5Ar5AN0JbWcoM4KgW8+G1bI=",
-        "owner": "CachyOS",
-        "repo": "linux-cachyos",
-        "rev": "fc29f6a9d1e48e0d5db29b4d53e0dbfadd0d75b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "CachyOS",
-        "repo": "linux-cachyos",
         "type": "github"
       }
     },
@@ -153,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784907716,
-        "narHash": "sha256-Ut8XgrSfgDi5QO71SZxVpjibIZa08dJnNdzm0PWtTxc=",
+        "lastModified": 1785444417,
+        "narHash": "sha256-9hxIB6McRAsHGlsy4HZIv5FJpfKwlpeuVmPntxj4J8I=",
         "owner": "AvengeMedia",
         "repo": "dank-greeter",
-        "rev": "d3c919158e135e2f64e5ad3b025887e3a8b3549f",
+        "rev": "f353eafdee856a2e1c6ce87ce551304e8a6ed404",
         "type": "github"
       },
       "original": {
@@ -175,11 +141,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784936204,
-        "narHash": "sha256-XNbDvIaPzqqIpgJynqSADAj7Yf8KlGJTo5S/fQJUBxs=",
+        "lastModified": 1785505021,
+        "narHash": "sha256-wcyPC+psdQT6l5i2n11a2CIweurnjvs2tQExqKawbUY=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "8bb7396362357650a80dcc8d81407095c91c7dcf",
+        "rev": "ef191babb72c83bf16254d3f9416e7b2e8ef61d6",
         "type": "github"
       },
       "original": {
@@ -207,11 +173,11 @@
     "dank-qml-common_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1784935106,
-        "narHash": "sha256-aVgOBRynme6XNKYCZlf/oCjPDZFwddyUQPRRkEupC3c=",
+        "lastModified": 1785445867,
+        "narHash": "sha256-l9IRsLIVZ7bV+KMuTdCga89tGt4lpdMXhQR7f/2qoe4=",
         "owner": "AvengeMedia",
         "repo": "dank-qml-common",
-        "rev": "a172b39841d8f42bac46ac133b76cade1fae91b4",
+        "rev": "3b06bd9372e18bc8086cc3958d4f677d57fbfdd8",
         "type": "github"
       },
       "original": {
@@ -263,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785047501,
-        "narHash": "sha256-jXSoCZ3+RSRvmhq3DrVH8hyxIM6jV1uOuxadtjgYzVY=",
+        "lastModified": 1785549484,
+        "narHash": "sha256-HUJj6imBS1w94owgtuma+BElDu6G3A48ozQpiSGzALY=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "f7a79cd65c5609222948e19d43c2cae0049395e3",
+        "rev": "c4c61b8c022901c5a481f5076a2cf2f1ecd5bd97",
         "type": "github"
       },
       "original": {
@@ -428,11 +394,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1784255282,
-        "narHash": "sha256-srM+PTqxfyvbQ0BevsOtP8vQv/Ox6OMtY4DktoDxLKg=",
+        "lastModified": 1785282747,
+        "narHash": "sha256-ZwdMXUu0Udb4yzI65+psyJeUF+wexByNEvTUSx1xjVs=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "66ddd2f69a5c4677f0095c6f70eea1217dc45749",
+        "rev": "56c46842d70754345c4a4581b8cbebe87b8fc067",
         "type": "github"
       },
       "original": {
@@ -832,11 +798,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784350909,
-        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
         "type": "github"
       },
       "original": {
@@ -1102,11 +1068,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784938247,
-        "narHash": "sha256-yO+L8iSAjvDA6gm+9Jmr+pLt9FkGU5j5mT1DdFpz9Wk=",
+        "lastModified": 1785543227,
+        "narHash": "sha256-jpFUp0N+wu/D9OCQHRr09rSR+1LKzwwn4wYSMF+/t94=",
         "ref": "refs/heads/main",
-        "rev": "baa586fdd74462f853e478cd3f2c60c57cbd08ae",
-        "revCount": 147,
+        "rev": "d73801e0812d2c6e3afca3cf20e5a7f24b10972a",
+        "revCount": 156,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1242,11 +1208,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1785036958,
-        "narHash": "sha256-O15qkhH/TmJ4KkUvGSeCud5+bzdAjToi8FudQN/BmzE=",
+        "lastModified": 1785554838,
+        "narHash": "sha256-JyJODyGrRSmLmXpPrpTqorRRZNaB42BPwIDyKckjw1k=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "198224bf38a56259616e990328dcc685b059845b",
+        "rev": "74dcc474028b87a9cca116815c003b1b5b731eea",
         "type": "github"
       },
       "original": {
@@ -1284,11 +1250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784059782,
-        "narHash": "sha256-uIMxTemoRKv+qdP9OExl9wbfr5+JE6VcSESOeEVV2Ps=",
+        "lastModified": 1785072517,
+        "narHash": "sha256-eh6isB4Gt3Wry1fPqRI1qKWySjDbalvaBwToG82jcR4=",
         "owner": "nixpak",
         "repo": "nixpak",
-        "rev": "a6e7b272a4483d14f5c057a9b5c0d19f15b401e5",
+        "rev": "333bd8c7ca0c014e61be1933b3c131c9dfa20218",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1265,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784966893,
-        "narHash": "sha256-WCrs/9bdH+gzSZit3UrSa4sWdyZ8+uC5x5bymPgBHMg=",
+        "lastModified": 1785501464,
+        "narHash": "sha256-TOU5zN4qZzi8Fd4FOPaO5liKYo+RHlleHDasnyI3S78=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "328e42b4f861ae88cf3643962ed5c4ff918f2ba8",
+        "rev": "7e2391fc6abe0c200affe8e8a4efd2cc891fcffb",
         "type": "github"
       },
       "original": {
@@ -1391,11 +1357,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -1535,11 +1501,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -1583,11 +1549,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1784856561,
-        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {
@@ -1605,11 +1571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785049820,
-        "narHash": "sha256-2ib2KIInDx2RwmuRdbExW6eI41p4W1I8FOEYHZOJv+g=",
+        "lastModified": 1785584152,
+        "narHash": "sha256-KvBh1d/kLXjjOdrQRasv/bccBlh7+LHs7oV7PdlnAng=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "44274acc3366fec2d617b4c4d31b021537c221ab",
+        "rev": "d21fdc75128076e6447ef910d10ff35b4e499e5b",
         "type": "github"
       },
       "original": {
@@ -1702,11 +1668,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784896537,
-        "narHash": "sha256-TuVxm2b3crbGs8qDNhQFQ+Yn93usHQN6wVNo42DsQG4=",
+        "lastModified": 1785255875,
+        "narHash": "sha256-D0DGI/+nrVA3Ydk+g0eCzAU0Gw+pDA8IBRT/IcCN+DI=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "68a03e5a65cd2d4242a8220ba8dbed0e04a9c2ee",
+        "rev": "500563b93db47046c4c34f8873d9a576b01e33a4",
         "type": "github"
       },
       "original": {
@@ -1744,11 +1710,11 @@
         "treefmt-nix": "treefmt-nix_5"
       },
       "locked": {
-        "lastModified": 1784836877,
-        "narHash": "sha256-Cl3isSZw4YL/wIVLKV7/iUIVxtEEMPYCT4CWw+iPCP4=",
+        "lastModified": 1785459394,
+        "narHash": "sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0=",
         "owner": "Swarsel",
         "repo": "pedantix",
-        "rev": "cfb564b6c4b41ce7c2b7cc17b9709e332ac81916",
+        "rev": "91464672e038a77c8dc64c68d26128859ca10870",
         "type": "github"
       },
       "original": {
@@ -1779,11 +1745,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784799776,
-        "narHash": "sha256-6AM0doj8hSNav9qkX4dOHOp1LSjegdQ+VmzDz9MnWAs=",
+        "lastModified": 1785134238,
+        "narHash": "sha256-bv5gar+ZAXZCJH7UOv0eRFILKt5RKA/3px/XbVR98Cg=",
         "ref": "master",
-        "rev": "10b439fc6e3fd65c15fe1c486271b31da05ed023",
-        "revCount": 833,
+        "rev": "43d4fa9e883cb03239b3d578c9c57070f4fbd281",
+        "revCount": 834,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },

--- a/modules/surfaces/niri/default.nix
+++ b/modules/surfaces/niri/default.nix
@@ -55,4 +55,8 @@
 
     overlays.niri-nix = inputs.niri-nix.overlays.niri-nix;
   };
+
+  flake.overlays.niri = final: prev: {
+    libdisplay-info_0_3 = prev.libdisplay-info;
+  };
 }


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/6669b7b5f6b468e2be07711fe65d9e6c30560975?narHash=sha256-z6uYlDlOqJOl4vfOr5jGeF90UR90hhQrRsAOtSqSq7g%3D' (2026-07-25)
  → 'github:xddxdd/nix-cachyos-kernel/4f3c8ca048091c5fbad5447c660133ac1a151ac7?narHash=sha256-QeJMNuRgY5E7pAYTjgMO8Te9Rg0AEI5CgS8EYQpZzHw%3D' (2026-07-31)
• Removed input 'cachyos-kernel/cachyos-kernel'
• Removed input 'cachyos-kernel/cachyos-kernel-patches'
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/328e42b4f861ae88cf3643962ed5c4ff918f2ba8?narHash=sha256-WCrs/9bdH%2BgzSZit3UrSa4sWdyZ8%2BuC5x5bymPgBHMg%3D' (2026-07-25)
  → 'github:NixOS/nixpkgs/7e2391fc6abe0c200affe8e8a4efd2cc891fcffb?narHash=sha256-TOU5zN4qZzi8Fd4FOPaO5liKYo%2BRHlleHDasnyI3S78%3D' (2026-07-31)
• Updated input 'dank-greeter':
    'github:AvengeMedia/dank-greeter/d3c919158e135e2f64e5ad3b025887e3a8b3549f?narHash=sha256-Ut8XgrSfgDi5QO71SZxVpjibIZa08dJnNdzm0PWtTxc%3D' (2026-07-24)
  → 'github:AvengeMedia/dank-greeter/f353eafdee856a2e1c6ce87ce551304e8a6ed404?narHash=sha256-9hxIB6McRAsHGlsy4HZIv5FJpfKwlpeuVmPntxj4J8I%3D' (2026-07-30)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/8bb7396362357650a80dcc8d81407095c91c7dcf?narHash=sha256-XNbDvIaPzqqIpgJynqSADAj7Yf8KlGJTo5S/fQJUBxs%3D' (2026-07-24)
  → 'github:AvengeMedia/DankMaterialShell/ef191babb72c83bf16254d3f9416e7b2e8ef61d6?narHash=sha256-wcyPC%2BpsdQT6l5i2n11a2CIweurnjvs2tQExqKawbUY%3D' (2026-07-31)
• Updated input 'dank-material-shell/dank-qml-common':
    'github:AvengeMedia/dank-qml-common/a172b39841d8f42bac46ac133b76cade1fae91b4?narHash=sha256-aVgOBRynme6XNKYCZlf/oCjPDZFwddyUQPRRkEupC3c%3D' (2026-07-24)
  → 'github:AvengeMedia/dank-qml-common/3b06bd9372e18bc8086cc3958d4f677d57fbfdd8?narHash=sha256-l9IRsLIVZ7bV%2BKMuTdCga89tGt4lpdMXhQR7f/2qoe4%3D' (2026-07-30)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/f7a79cd65c5609222948e19d43c2cae0049395e3?narHash=sha256-jXSoCZ3%2BRSRvmhq3DrVH8hyxIM6jV1uOuxadtjgYzVY%3D' (2026-07-26)
  → 'github:AvengeMedia/dms-plugin-registry/c4c61b8c022901c5a481f5076a2cf2f1ecd5bd97?narHash=sha256-HUJj6imBS1w94owgtuma%2BBElDu6G3A48ozQpiSGzALY%3D' (2026-08-01)
• Updated input 'flake-file':
    'github:vic/flake-file/66ddd2f69a5c4677f0095c6f70eea1217dc45749?narHash=sha256-srM%2BPTqxfyvbQ0BevsOtP8vQv/Ox6OMtY4DktoDxLKg%3D' (2026-07-17)
  → 'github:vic/flake-file/56c46842d70754345c4a4581b8cbebe87b8fc067?narHash=sha256-ZwdMXUu0Udb4yzI65%2BpsyJeUF%2BwexByNEvTUSx1xjVs%3D' (2026-07-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4ce190229c73d44536caa7072f6308fb2d8feeb3?narHash=sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE%2BKzCrM%3D' (2026-07-18)
  → 'github:nix-community/home-manager/d4fd24667c8cbef124bb70a20380cab75ec8474d?narHash=sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM%3D' (2026-07-27)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=baa586fdd74462f853e478cd3f2c60c57cbd08ae' (2026-07-25)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=d73801e0812d2c6e3afca3cf20e5a7f24b10972a' (2026-08-01)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
  → 'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/198224bf38a56259616e990328dcc685b059845b?narHash=sha256-O15qkhH/TmJ4KkUvGSeCud5%2BbzdAjToi8FudQN/BmzE%3D' (2026-07-26)
  → 'github:fufexan/nix-gaming/74dcc474028b87a9cca116815c003b1b5b731eea?narHash=sha256-JyJODyGrRSmLmXpPrpTqorRRZNaB42BPwIDyKckjw1k%3D' (2026-08-01)
• Updated input 'nixpak':
    'github:nixpak/nixpak/a6e7b272a4483d14f5c057a9b5c0d19f15b401e5?narHash=sha256-uIMxTemoRKv%2BqdP9OExl9wbfr5%2BJE6VcSESOeEVV2Ps%3D' (2026-07-14)
  → 'github:nixpak/nixpak/333bd8c7ca0c014e61be1933b3c131c9dfa20218?narHash=sha256-eh6isB4Gt3Wry1fPqRI1qKWySjDbalvaBwToG82jcR4%3D' (2026-07-26)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/597283ad8aa0b331c788e97c4c262d58877074ef?narHash=sha256-J%2BBx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A%3D' (2026-07-24)
  → 'github:NixOS/nixpkgs/5b4f72e1705a63aace42900610c4db82cb4af0ec?narHash=sha256-p00vplVOyfKGlhju0%2BeGGPAxyYYKaY0lpyuoHLFIx2Y%3D' (2026-07-31)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
  → 'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
• Updated input 'nur':
    'github:nix-community/NUR/44274acc3366fec2d617b4c4d31b021537c221ab?narHash=sha256-2ib2KIInDx2RwmuRdbExW6eI41p4W1I8FOEYHZOJv%2Bg%3D' (2026-07-26)
  → 'github:nix-community/NUR/d21fdc75128076e6447ef910d10ff35b4e499e5b?narHash=sha256-KvBh1d/kLXjjOdrQRasv/bccBlh7%2BLHs7oV7PdlnAng%3D' (2026-08-01)
• Updated input 'paneru':
    'github:karinushka/paneru/68a03e5a65cd2d4242a8220ba8dbed0e04a9c2ee?narHash=sha256-TuVxm2b3crbGs8qDNhQFQ%2BYn93usHQN6wVNo42DsQG4%3D' (2026-07-24)
  → 'github:karinushka/paneru/500563b93db47046c4c34f8873d9a576b01e33a4?narHash=sha256-D0DGI/%2BnrVA3Ydk%2Bg0eCzAU0Gw%2BpDA8IBRT/IcCN%2BDI%3D' (2026-07-28)
• Updated input 'pedantix':
    'github:Swarsel/pedantix/cfb564b6c4b41ce7c2b7cc17b9709e332ac81916?narHash=sha256-Cl3isSZw4YL/wIVLKV7/iUIVxtEEMPYCT4CWw%2BiPCP4%3D' (2026-07-23)
  → 'github:Swarsel/pedantix/91464672e038a77c8dc64c68d26128859ca10870?narHash=sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0%3D' (2026-07-31)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=10b439fc6e3fd65c15fe1c486271b31da05ed023' (2026-07-23)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=43d4fa9e883cb03239b3d578c9c57070f4fbd281' (2026-07-27)```