### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785524300,
-        "narHash": "sha256-QeJMNuRgY5E7pAYTjgMO8Te9Rg0AEI5CgS8EYQpZzHw=",
+        "lastModified": 1785870829,
+        "narHash": "sha256-l+RTmz09TxwWJRLQuc+cKi3yY0K4PSz8tRPTbBUvaVo=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "4f3c8ca048091c5fbad5447c660133ac1a151ac7",
+        "rev": "879f45ee15a3b06fdbbf9b6dc825c5fbca137fcd",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785505021,
-        "narHash": "sha256-wcyPC+psdQT6l5i2n11a2CIweurnjvs2tQExqKawbUY=",
+        "lastModified": 1786745379,
+        "narHash": "sha256-YwKRVAmiUuFCzve8eAf+1xNpbOwfSLgadccYZKPyYzw=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "ef191babb72c83bf16254d3f9416e7b2e8ef61d6",
+        "rev": "fb9f00a61616456115c2b63128fb51bba93494ee",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     "dank-qml-common_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1785445867,
-        "narHash": "sha256-l9IRsLIVZ7bV+KMuTdCga89tGt4lpdMXhQR7f/2qoe4=",
+        "lastModified": 1786649745,
+        "narHash": "sha256-61G4G6nQqSV4DWNyZAYlZOLAY6+Ug+JQA1SaifacaSI=",
         "owner": "AvengeMedia",
         "repo": "dank-qml-common",
-        "rev": "3b06bd9372e18bc8086cc3958d4f677d57fbfdd8",
+        "rev": "3373281fdba24e030ef47325f9db01494780a4a3",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785617619,
-        "narHash": "sha256-MDUHB9hKjP6nse+zTqgbcb1/pBgjV/FJ1j/4hkChu+M=",
+        "lastModified": 1786310616,
+        "narHash": "sha256-aQOU08ECTd0savQD80AIGG9sqQ41zWHcWZeuUzz39ts=",
         "owner": "AvengeMedia",
         "repo": "dcal",
-        "rev": "01a431722fe2afbfc6e99698a7ba9894ca834a5e",
+        "rev": "a57a879061cd482c416d5ece44cb529249c37b06",
         "type": "github"
       },
       "original": {
@@ -266,11 +266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785549484,
-        "narHash": "sha256-HUJj6imBS1w94owgtuma+BElDu6G3A48ozQpiSGzALY=",
+        "lastModified": 1786754630,
+        "narHash": "sha256-QNZ7c5U4/glM3evnXZEoxx99odM1qWw/N1/6p9C7k9M=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "c4c61b8c022901c5a481f5076a2cf2f1ecd5bd97",
+        "rev": "f1d584f1c3f17203cb544ba65b67de2797cdf070",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -1037,11 +1037,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1785543227,
-        "narHash": "sha256-jpFUp0N+wu/D9OCQHRr09rSR+1LKzwwn4wYSMF+/t94=",
+        "lastModified": 1786752088,
+        "narHash": "sha256-tmZRrERoCnWGZ9NtdPDD72kPa2kl+LmmJt194SSuU4o=",
         "ref": "refs/heads/main",
-        "rev": "d73801e0812d2c6e3afca3cf20e5a7f24b10972a",
-        "revCount": 156,
+        "rev": "01cb364fdb88786c0059fa80a2b539aa3a54e58e",
+        "revCount": 169,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1074,11 +1074,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1784570726,
-        "narHash": "sha256-9EMn69JBcFWFgUM7f0VBAX+jBby5b9H3M59U75+5yI4=",
+        "lastModified": 1786710356,
+        "narHash": "sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc",
+        "rev": "606284464d4a99bb35710fee68192bc71085ee7c",
         "type": "github"
       },
       "original": {
@@ -1097,11 +1097,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1784888556,
-        "narHash": "sha256-objrARvlyaoK3ib3xkgx4KoKZXbcNBZ8WTK/XheiPCE=",
+        "lastModified": 1786008908,
+        "narHash": "sha256-b/9Y2u4YIwLfIdfg8nYxzVRDjm9fAqsFtK8Ikaf8YTs=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "89d83133b5c65130171ebe0922a39dd53deb365b",
+        "rev": "094035e7a82b147dd09690074d6bb1f9f61ec7ba",
         "type": "github"
       },
       "original": {
@@ -1177,11 +1177,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1785554838,
-        "narHash": "sha256-JyJODyGrRSmLmXpPrpTqorRRZNaB42BPwIDyKckjw1k=",
+        "lastModified": 1786789564,
+        "narHash": "sha256-9RfAshi6/ou2P2NgiuHNtGGHghzmtpk0Z8uG3CqKa08=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "74dcc474028b87a9cca116815c003b1b5b731eea",
+        "rev": "5607f78eb46ce192a1fdf2f4f566682e769c7c35",
         "type": "github"
       },
       "original": {
@@ -1197,11 +1197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785046085,
-        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
+        "lastModified": 1786249295,
+        "narHash": "sha256-Y2mSr+HLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
+        "rev": "14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6",
         "type": "github"
       },
       "original": {
@@ -1234,11 +1234,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785501464,
-        "narHash": "sha256-TOU5zN4qZzi8Fd4FOPaO5liKYo+RHlleHDasnyI3S78=",
+        "lastModified": 1785859399,
+        "narHash": "sha256-pY4X50au95QrTpAbEm08pURmeU3/Ud2oa0s2XzpDdz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e2391fc6abe0c200affe8e8a4efd2cc891fcffb",
+        "rev": "85f62611fa3f3eacbcfe3bc7a6d6518b443ca442",
         "type": "github"
       },
       "original": {
@@ -1250,11 +1250,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1782614948,
-        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -1280,11 +1280,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1782614948,
-        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -1326,11 +1326,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -1470,11 +1470,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -1486,11 +1486,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {
@@ -1502,11 +1502,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784872115,
-        "narHash": "sha256-THPEF2po0fsoH8gNtp+Ae0XFDJH3N/ol7xO3v6VMTJU=",
+        "lastModified": 1785975029,
+        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "335f0738cb2fa9708f3f428e39d2eae975d1338d",
+        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
         "type": "github"
       },
       "original": {
@@ -1518,11 +1518,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1785491804,
-        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
+        "lastModified": 1786711500,
+        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
+        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
         "type": "github"
       },
       "original": {
@@ -1540,11 +1540,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785584152,
-        "narHash": "sha256-KvBh1d/kLXjjOdrQRasv/bccBlh7+LHs7oV7PdlnAng=",
+        "lastModified": 1786797664,
+        "narHash": "sha256-TfoAjYy4fr47Eux27UKwO899hyPtw7VAgWb9Wqrvkug=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d21fdc75128076e6447ef910d10ff35b4e499e5b",
+        "rev": "429068755d9b8322e29a6271d4227382acb941a9",
         "type": "github"
       },
       "original": {
@@ -1637,11 +1637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785255875,
-        "narHash": "sha256-D0DGI/+nrVA3Ydk+g0eCzAU0Gw+pDA8IBRT/IcCN+DI=",
+        "lastModified": 1786488242,
+        "narHash": "sha256-RfaQAA2lMPlBU2Umh386/OyuA4bJRElRwgMAF07HKUk=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "500563b93db47046c4c34f8873d9a576b01e33a4",
+        "rev": "d667379b14e3f127efe7d9649b909d8f4a325c41",
         "type": "github"
       },
       "original": {
@@ -1679,11 +1679,11 @@
         "treefmt-nix": "treefmt-nix_5"
       },
       "locked": {
-        "lastModified": 1785459394,
-        "narHash": "sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0=",
+        "lastModified": 1785851015,
+        "narHash": "sha256-zemqpfpXkHPGefuF8lgNrupH2RmB4GarQpIn5yVGiow=",
         "owner": "Swarsel",
         "repo": "pedantix",
-        "rev": "91464672e038a77c8dc64c68d26128859ca10870",
+        "rev": "57fb5794182b7574f48ff0d391485ab6af70bc8a",
         "type": "github"
       },
       "original": {
@@ -1694,11 +1694,11 @@
     },
     "quadlet-nix": {
       "locked": {
-        "lastModified": 1782004439,
-        "narHash": "sha256-OANOcPKJ3JThp2x/ccz4DDrGDY2hIgM5SBLI51swgfI=",
+        "lastModified": 1785695563,
+        "narHash": "sha256-kE3JCUeQA4CXlLl5TglmKceOJP+ZF/CwkHngiZ3yS00=",
         "owner": "SEIAROTg",
         "repo": "quadlet-nix",
-        "rev": "f1652b490b812c4e0b2a36565cdbedf87f35e438",
+        "rev": "b6ff6c4d6b36b8e29bce417b668597fab3e03160",
         "type": "github"
       },
       "original": {
@@ -1714,11 +1714,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785134238,
-        "narHash": "sha256-bv5gar+ZAXZCJH7UOv0eRFILKt5RKA/3px/XbVR98Cg=",
+        "lastModified": 1785704021,
+        "narHash": "sha256-eQtczKMAS4ItlB4pr1B3MqBZiyRVl2nkqNdtyRSQMa8=",
         "ref": "master",
-        "rev": "43d4fa9e883cb03239b3d578c9c57070f4fbd281",
-        "revCount": 834,
+        "rev": "28771c7c74b42e20afca0b1b63980cb46515537c",
+        "revCount": 835,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },
@@ -1773,11 +1773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {
@@ -1938,11 +1938,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784369104,
-        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
         "type": "github"
       },
       "original": {
@@ -2015,11 +2015,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1784679892,
-        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
+        "lastModified": 1786221058,
+        "narHash": "sha256-hF2atQzapHBLX5NFqJMcKZAWHfGkKQeNu1eQr46+AGg=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
+        "rev": "3bc915f09dd62bb2651a715114f9d140344bc6c1",
         "type": "github"
       },
       "original": {

--- a/modules/surfaces/lib/panel/dankmaterialshell/default.nix
+++ b/modules/surfaces/lib/panel/dankmaterialshell/default.nix
@@ -29,7 +29,6 @@
 
     programs.dank-material-shell = {
       enable = true;
-      dgop.package = pkgs.unstable.dgop;
       enableAudioWavelength = true;
       enableCalendarEvents = true;
       enableClipboardPaste = true;


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/4f3c8ca048091c5fbad5447c660133ac1a151ac7?narHash=sha256-QeJMNuRgY5E7pAYTjgMO8Te9Rg0AEI5CgS8EYQpZzHw%3D' (2026-07-31)
  → 'github:xddxdd/nix-cachyos-kernel/879f45ee15a3b06fdbbf9b6dc825c5fbca137fcd?narHash=sha256-l%2BRTmz09TxwWJRLQuc%2BcKi3yY0K4PSz8tRPTbBUvaVo%3D' (2026-08-04)
• Updated input 'cachyos-kernel/flake-parts':
    'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'cachyos-kernel/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
  → 'github:nix-community/nixpkgs.lib/0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c?narHash=sha256-OmshNvn2vupOFpYinLUu%2B1Dnpu4n7Q5N3ggGVNHpkUI%3D' (2026-07-26)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/7e2391fc6abe0c200affe8e8a4efd2cc891fcffb?narHash=sha256-TOU5zN4qZzi8Fd4FOPaO5liKYo%2BRHlleHDasnyI3S78%3D' (2026-07-31)
  → 'github:NixOS/nixpkgs/85f62611fa3f3eacbcfe3bc7a6d6518b443ca442?narHash=sha256-pY4X50au95QrTpAbEm08pURmeU3/Ud2oa0s2XzpDdz8%3D' (2026-08-04)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/ef191babb72c83bf16254d3f9416e7b2e8ef61d6?narHash=sha256-wcyPC%2BpsdQT6l5i2n11a2CIweurnjvs2tQExqKawbUY%3D' (2026-07-31)
  → 'github:AvengeMedia/DankMaterialShell/fb9f00a61616456115c2b63128fb51bba93494ee?narHash=sha256-YwKRVAmiUuFCzve8eAf%2B1xNpbOwfSLgadccYZKPyYzw%3D' (2026-08-14)
• Updated input 'dank-material-shell/dank-qml-common':
    'github:AvengeMedia/dank-qml-common/3b06bd9372e18bc8086cc3958d4f677d57fbfdd8?narHash=sha256-l9IRsLIVZ7bV%2BKMuTdCga89tGt4lpdMXhQR7f/2qoe4%3D' (2026-07-30)
  → 'github:AvengeMedia/dank-qml-common/3373281fdba24e030ef47325f9db01494780a4a3?narHash=sha256-61G4G6nQqSV4DWNyZAYlZOLAY6%2BUg%2BJQA1SaifacaSI%3D' (2026-08-13)
• Updated input 'dcal':
    'github:AvengeMedia/dcal/01a431722fe2afbfc6e99698a7ba9894ca834a5e?narHash=sha256-MDUHB9hKjP6nse%2BzTqgbcb1/pBgjV/FJ1j/4hkChu%2BM%3D' (2026-08-01)
  → 'github:AvengeMedia/dcal/a57a879061cd482c416d5ece44cb529249c37b06?narHash=sha256-aQOU08ECTd0savQD80AIGG9sqQ41zWHcWZeuUzz39ts%3D' (2026-08-09)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/c4c61b8c022901c5a481f5076a2cf2f1ecd5bd97?narHash=sha256-HUJj6imBS1w94owgtuma%2BBElDu6G3A48ozQpiSGzALY%3D' (2026-08-01)
  → 'github:AvengeMedia/dms-plugin-registry/f1d584f1c3f17203cb544ba65b67de2797cdf070?narHash=sha256-QNZ7c5U4/glM3evnXZEoxx99odM1qWw/N1/6p9C7k9M%3D' (2026-08-15)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=d73801e0812d2c6e3afca3cf20e5a7f24b10972a' (2026-08-01)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=01cb364fdb88786c0059fa80a2b539aa3a54e58e' (2026-08-15)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc?narHash=sha256-9EMn69JBcFWFgUM7f0VBAX%2BjBby5b9H3M59U75%2B5yI4%3D' (2026-07-20)
  → 'github:YaLTeR/niri/606284464d4a99bb35710fee68192bc71085ee7c?narHash=sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY%3D' (2026-08-14)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
  → 'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'niri-nix/xwayland-satellite-unstable':
    'github:Supreeeme/xwayland-satellite/8d135d3b2854b30fd01ea6cd6c27e523dd50a839?narHash=sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk%3D' (2026-07-22)
  → 'github:Supreeeme/xwayland-satellite/3bc915f09dd62bb2651a715114f9d140344bc6c1?narHash=sha256-hF2atQzapHBLX5NFqJMcKZAWHfGkKQeNu1eQr46%2BAGg%3D' (2026-08-08)
• Updated input 'nix-citizen':
    'github:LovingMelody/nix-citizen/89d83133b5c65130171ebe0922a39dd53deb365b?narHash=sha256-objrARvlyaoK3ib3xkgx4KoKZXbcNBZ8WTK/XheiPCE%3D' (2026-07-24)
  → 'github:LovingMelody/nix-citizen/094035e7a82b147dd09690074d6bb1f9f61ec7ba?narHash=sha256-b/9Y2u4YIwLfIdfg8nYxzVRDjm9fAqsFtK8Ikaf8YTs%3D' (2026-08-06)
• Updated input 'nix-citizen/nixpkgs':
    'github:NixOS/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
  → 'github:NixOS/nixpkgs/e72e4f299401a3689d4b3d5fc6496b11db7064eb?narHash=sha256-8fsyqeO%2BmJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs%3D' (2026-08-04)
• Updated input 'nix-citizen/treefmt-nix':
    'github:numtide/treefmt-nix/df3c0640565d04a0261253cdd89fce78ec50168a?narHash=sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0%3D' (2026-07-18)
  → 'github:numtide/treefmt-nix/d1187f8bc71fb8aab02395869ec3f5c1920f75c0?narHash=sha256-XE1lKgQ3eIO3E7zWryqcRsax%2BmYXod/5RHBn4YaR9YE%3D' (2026-07-29)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/74dcc474028b87a9cca116815c003b1b5b731eea?narHash=sha256-JyJODyGrRSmLmXpPrpTqorRRZNaB42BPwIDyKckjw1k%3D' (2026-08-01)
  → 'github:fufexan/nix-gaming/5607f78eb46ce192a1fdf2f4f566682e769c7c35?narHash=sha256-9RfAshi6/ou2P2NgiuHNtGGHghzmtpk0Z8uG3CqKa08%3D' (2026-08-15)
• Updated input 'nix-gaming/flake-parts':
    'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'nix-gaming/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
  → 'github:nix-community/nixpkgs.lib/0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c?narHash=sha256-OmshNvn2vupOFpYinLUu%2B1Dnpu4n7Q5N3ggGVNHpkUI%3D' (2026-07-26)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/335f0738cb2fa9708f3f428e39d2eae975d1338d?narHash=sha256-THPEF2po0fsoH8gNtp%2BAe0XFDJH3N/ol7xO3v6VMTJU%3D' (2026-07-24)
  → 'github:NixOS/nixpkgs/70ce234312134a463ba7728e94da2486a1d237ac?narHash=sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU%3D' (2026-08-06)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/11665045df8b9938ef811a3bfdc65cffb02b4b70?narHash=sha256-UiK%2BmmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y%3D' (2026-07-26)
  → 'github:nix-community/nix-index-database/14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6?narHash=sha256-Y2mSr%2BHLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I%3D' (2026-08-09)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5b4f72e1705a63aace42900610c4db82cb4af0ec?narHash=sha256-p00vplVOyfKGlhju0%2BeGGPAxyYYKaY0lpyuoHLFIx2Y%3D' (2026-07-31)
  → 'github:NixOS/nixpkgs/02e08985a27c65ffd33d434eeb2e660a2e4dc84d?narHash=sha256-QvnceIGTBeDvDd9oCn%2BGvdsnkquliuwbVgpiRH68qaQ%3D' (2026-08-14)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
  → 'github:NixOS/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/d21fdc75128076e6447ef910d10ff35b4e499e5b?narHash=sha256-KvBh1d/kLXjjOdrQRasv/bccBlh7%2BLHs7oV7PdlnAng%3D' (2026-08-01)
  → 'github:nix-community/NUR/429068755d9b8322e29a6271d4227382acb941a9?narHash=sha256-TfoAjYy4fr47Eux27UKwO899hyPtw7VAgWb9Wqrvkug%3D' (2026-08-15)
• Updated input 'paneru':
    'github:karinushka/paneru/500563b93db47046c4c34f8873d9a576b01e33a4?narHash=sha256-D0DGI/%2BnrVA3Ydk%2Bg0eCzAU0Gw%2BpDA8IBRT/IcCN%2BDI%3D' (2026-07-28)
  → 'github:karinushka/paneru/d667379b14e3f127efe7d9649b909d8f4a325c41?narHash=sha256-RfaQAA2lMPlBU2Umh386/OyuA4bJRElRwgMAF07HKUk%3D' (2026-08-11)
• Updated input 'pedantix':
    'github:Swarsel/pedantix/91464672e038a77c8dc64c68d26128859ca10870?narHash=sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0%3D' (2026-07-31)
  → 'github:Swarsel/pedantix/57fb5794182b7574f48ff0d391485ab6af70bc8a?narHash=sha256-zemqpfpXkHPGefuF8lgNrupH2RmB4GarQpIn5yVGiow%3D' (2026-08-04)
• Updated input 'quadlet-nix':
    'github:SEIAROTg/quadlet-nix/f1652b490b812c4e0b2a36565cdbedf87f35e438?narHash=sha256-OANOcPKJ3JThp2x/ccz4DDrGDY2hIgM5SBLI51swgfI%3D' (2026-06-21)
  → 'github:SEIAROTg/quadlet-nix/b6ff6c4d6b36b8e29bce417b668597fab3e03160?narHash=sha256-kE3JCUeQA4CXlLl5TglmKceOJP%2BZF/CwkHngiZ3yS00%3D' (2026-08-02)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=43d4fa9e883cb03239b3d578c9c57070f4fbd281' (2026-07-27)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=28771c7c74b42e20afca0b1b63980cb46515537c' (2026-08-02)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f1406619a3884cd5c47992a70b8b35c9c0fcb4c9?narHash=sha256-aCWC8ngycU7OdJrU2%2BJe3qf%2B1a2ykuBvpPhZT/9tXMc%3D' (2026-07-04)
  → 'github:Mic92/sops-nix/a8627b21b9107c5711c96b84f32a9a4b3d45295f?narHash=sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck%3D' (2026-08-13)```