### PR TITLE
build(flake): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785870829,
-        "narHash": "sha256-l+RTmz09TxwWJRLQuc+cKi3yY0K4PSz8tRPTbBUvaVo=",
+        "lastModified": 1787248950,
+        "narHash": "sha256-eq5FwprGyjytM68pitTTFT3fi0cSsF1M6v7h3rdcqj0=",
         "owner": "xddxdd",
         "repo": "nix-cachyos-kernel",
-        "rev": "879f45ee15a3b06fdbbf9b6dc825c5fbca137fcd",
+        "rev": "c69c33c24148defbcc34ab25456cc460bc33fdbb",
         "type": "github"
       },
       "original": {
@@ -111,6 +111,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1785541369,
+        "narHash": "sha256-6VCYI5xashcnAR1lambqt9FGh0F6kYhg1P2Z0VDlr48=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "508ff4829aefddee8ea62291e86b144b58365724",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "dank-greeter": {
       "inputs": {
         "dank-qml-common": "dank-qml-common",
@@ -119,11 +134,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785444417,
-        "narHash": "sha256-9hxIB6McRAsHGlsy4HZIv5FJpfKwlpeuVmPntxj4J8I=",
+        "lastModified": 1787346578,
+        "narHash": "sha256-yhhFqTRpo6PuSmA2C1S/RwsunJCXLB437PkJXMxJ6gU=",
         "owner": "AvengeMedia",
         "repo": "dank-greeter",
-        "rev": "f353eafdee856a2e1c6ce87ce551304e8a6ed404",
+        "rev": "e957e4388fb04c30879200a1b58b7d27c9e51f2c",
         "type": "github"
       },
       "original": {
@@ -141,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786745379,
-        "narHash": "sha256-YwKRVAmiUuFCzve8eAf+1xNpbOwfSLgadccYZKPyYzw=",
+        "lastModified": 1787367018,
+        "narHash": "sha256-DHDTFjVvVNhdFJ6OEspjey8TVpGDcXT0ER8w9Y3Rntg=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "fb9f00a61616456115c2b63128fb51bba93494ee",
+        "rev": "b482e9b89877ef86726804ed9827aba33c5b9cbd",
         "type": "github"
       },
       "original": {
@@ -173,11 +188,11 @@
     "dank-qml-common_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1786649745,
-        "narHash": "sha256-61G4G6nQqSV4DWNyZAYlZOLAY6+Ug+JQA1SaifacaSI=",
+        "lastModified": 1787335146,
+        "narHash": "sha256-O/TmlR3EvOlKknz6AB8xDeUUCv3sgsIHdejgHJcdlGM=",
         "owner": "AvengeMedia",
         "repo": "dank-qml-common",
-        "rev": "3373281fdba24e030ef47325f9db01494780a4a3",
+        "rev": "720d75089580f1f3b7a2d6ed4b39e823734ceefa",
         "type": "github"
       },
       "original": {
@@ -210,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786310616,
-        "narHash": "sha256-aQOU08ECTd0savQD80AIGG9sqQ41zWHcWZeuUzz39ts=",
+        "lastModified": 1787335306,
+        "narHash": "sha256-v1jjjpz9YJQS9zQEpB+U8AybBoETdfg41AZTL9L9Y/g=",
         "owner": "AvengeMedia",
         "repo": "dcal",
-        "rev": "a57a879061cd482c416d5ece44cb529249c37b06",
+        "rev": "fe61f4e69e2178511711c3ac254539cd6d951a49",
         "type": "github"
       },
       "original": {
@@ -266,11 +281,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786754630,
-        "narHash": "sha256-QNZ7c5U4/glM3evnXZEoxx99odM1qWw/N1/6p9C7k9M=",
+        "lastModified": 1787325910,
+        "narHash": "sha256-aIgj4qdPOMd1A0npFStI+d5UxLcwuYjIw/kXSPyNZsw=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "f1d584f1c3f17203cb544ba65b67de2797cdf070",
+        "rev": "b65b029182b781c7d61ecfe1561eaae3fd059554",
         "type": "github"
       },
       "original": {
@@ -459,11 +474,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1777898446,
-        "narHash": "sha256-tTEOTTjMHd8Vffn4hehLTPgOXXxJ27xfkf4DoyZgD7s=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5d82aa3d6b5da25dbfec1a995750a70a03b8c659",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -812,11 +827,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119570,
-        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "lastModified": 1787377438,
+        "narHash": "sha256-Sxu1NLTD/Ern6hFGLlZmtKCSct3YQXZI/lls8RE1XeM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "rev": "65258d5c65a250189fde2e35f490d15e064c4c62",
         "type": "github"
       },
       "original": {
@@ -893,11 +908,11 @@
     },
     "import-tree_3": {
       "locked": {
-        "lastModified": 1773693634,
-        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "lastModified": 1784254960,
+        "narHash": "sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "rev": "4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69",
         "type": "github"
       },
       "original": {
@@ -1037,11 +1052,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1786752088,
-        "narHash": "sha256-tmZRrERoCnWGZ9NtdPDD72kPa2kl+LmmJt194SSuU4o=",
+        "lastModified": 1787097724,
+        "narHash": "sha256-y5q/XFRPi5TBWdh5MhqxJZhfmzqJO0bYNLZHE7WTqso=",
         "ref": "refs/heads/main",
-        "rev": "01cb364fdb88786c0059fa80a2b539aa3a54e58e",
-        "revCount": 169,
+        "rev": "ecd0e136e75dc37967f5a6a5fea5a99613c503c1",
+        "revCount": 171,
         "type": "git",
         "url": "https://codeberg.org/BANanaD3V/niri-nix"
       },
@@ -1074,11 +1089,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1786710356,
-        "narHash": "sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY=",
+        "lastModified": 1787066149,
+        "narHash": "sha256-uJKImwjqQ6Y+5b1IN93j6rEKGRoR0CsOuC/7vqluhJM=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "606284464d4a99bb35710fee68192bc71085ee7c",
+        "rev": "e9b215fef4b11ad36776553fb8bd45118ef03b03",
         "type": "github"
       },
       "original": {
@@ -1139,11 +1154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
@@ -1177,11 +1192,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1786789564,
-        "narHash": "sha256-9RfAshi6/ou2P2NgiuHNtGGHghzmtpk0Z8uG3CqKa08=",
+        "lastModified": 1787362090,
+        "narHash": "sha256-2XyURKmhVfr2yXr6T4uBPArikpdDyKZTuYLTIpKpzH4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "5607f78eb46ce192a1fdf2f4f566682e769c7c35",
+        "rev": "5ba87d8c49b6101c5a5715fa3145a71f34c93186",
         "type": "github"
       },
       "original": {
@@ -1197,11 +1212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786249295,
-        "narHash": "sha256-Y2mSr+HLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I=",
+        "lastModified": 1786852476,
+        "narHash": "sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6",
+        "rev": "c7962dc97b45129df8d751bedaf37beb5a17706e",
         "type": "github"
       },
       "original": {
@@ -1234,11 +1249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785859399,
-        "narHash": "sha256-pY4X50au95QrTpAbEm08pURmeU3/Ud2oa0s2XzpDdz8=",
+        "lastModified": 1787234702,
+        "narHash": "sha256-kvsnFCG4T5dmUj7BMcmpuPZjZNSjOZfhXUdjiBQG2xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f62611fa3f3eacbcfe3bc7a6d6518b443ca442",
+        "rev": "5cca3a89405eb65d2adb43754c2af8dac7b6f2e1",
         "type": "github"
       },
       "original": {
@@ -1295,11 +1310,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1326,11 +1341,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -1470,11 +1485,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
         "type": "github"
       },
       "original": {
@@ -1502,11 +1517,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1785975029,
-        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
+        "lastModified": 1786593342,
+        "narHash": "sha256-smTKQXMLLStzc8zJevMCckbk3My7SvbbLmPYZUJJKW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
+        "rev": "6b5e5b7a6631f065bf6908986990b37d845f847f",
         "type": "github"
       },
       "original": {
@@ -1518,11 +1533,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1787204541,
+        "narHash": "sha256-OURZPknrTjQrlNyxPdqzyqmU/81Wes1CUP/Ft1Rv/YI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "5880666fd9eb563038431edb35c2d0aa595884e6",
         "type": "github"
       },
       "original": {
@@ -1540,11 +1555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786797664,
-        "narHash": "sha256-TfoAjYy4fr47Eux27UKwO899hyPtw7VAgWb9Wqrvkug=",
+        "lastModified": 1787402847,
+        "narHash": "sha256-3r8M+7PJ98PuXuiPnOVRBGWleZVotH740FzsaXOfBmc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "429068755d9b8322e29a6271d4227382acb941a9",
+        "rev": "5733b00a2d9b7d7035928d0c0e26c0ad4eb2b5af",
         "type": "github"
       },
       "original": {
@@ -1598,11 +1613,11 @@
         "sort-nvim": "sort-nvim"
       },
       "locked": {
-        "lastModified": 1787166093,
-        "narHash": "sha256-FI1Gb+o4hXhd01lNiDKQ51Xh8hq9OgaGF6+92ksp9ps=",
+        "lastModified": 1787246855,
+        "narHash": "sha256-Loi53INnwUp/WjWJbq32w8xPdFSHmjWK/RBQ0XUsb2U=",
         "owner": "derethil",
         "repo": "nvim-config",
-        "rev": "d4045a166703de18a8c7fa0fe4dcc5e8549fd293",
+        "rev": "b75c240ebdfa32b430ea4cc7b101ccecaf8ae69e",
         "type": "github"
       },
       "original": {
@@ -1629,6 +1644,7 @@
     },
     "paneru": {
       "inputs": {
+        "crane": "crane",
         "flake-parts": "flake-parts_10",
         "import-tree": "import-tree_3",
         "nix-darwin": "nix-darwin_2",
@@ -1637,11 +1653,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786488242,
-        "narHash": "sha256-RfaQAA2lMPlBU2Umh386/OyuA4bJRElRwgMAF07HKUk=",
+        "lastModified": 1787166919,
+        "narHash": "sha256-rgp2aLduKyyi7dpUzKO9FXszaTM0+gyiogPPN6y92yA=",
         "owner": "karinushka",
         "repo": "paneru",
-        "rev": "d667379b14e3f127efe7d9649b909d8f4a325c41",
+        "rev": "bcf248ef60aa4c0b49002161b97bc6e268b05aa7",
         "type": "github"
       },
       "original": {
@@ -1714,11 +1730,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785704021,
-        "narHash": "sha256-eQtczKMAS4ItlB4pr1B3MqBZiyRVl2nkqNdtyRSQMa8=",
+        "lastModified": 1787279335,
+        "narHash": "sha256-CLX2Zp5i5BuLbOxNOkwRd9YY84IOrACNxBV79o9/F9Y=",
         "ref": "master",
-        "rev": "28771c7c74b42e20afca0b1b63980cb46515537c",
-        "revCount": 835,
+        "rev": "1a4716cde794a59928d9d9fc15f2afc7a95de360",
+        "revCount": 846,
         "type": "git",
         "url": "https://github.com/quickshell-mirror/quickshell"
       },


### PR DESCRIPTION
Automated updates by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.

```Flake lock file updates:

• Updated input 'cachyos-kernel':
    'github:xddxdd/nix-cachyos-kernel/879f45ee15a3b06fdbbf9b6dc825c5fbca137fcd?narHash=sha256-l%2BRTmz09TxwWJRLQuc%2BcKi3yY0K4PSz8tRPTbBUvaVo%3D' (2026-08-04)
  → 'github:xddxdd/nix-cachyos-kernel/c69c33c24148defbcc34ab25456cc460bc33fdbb?narHash=sha256-eq5FwprGyjytM68pitTTFT3fi0cSsF1M6v7h3rdcqj0%3D' (2026-08-20)
• Updated input 'cachyos-kernel/nixpkgs':
    'github:NixOS/nixpkgs/85f62611fa3f3eacbcfe3bc7a6d6518b443ca442?narHash=sha256-pY4X50au95QrTpAbEm08pURmeU3/Ud2oa0s2XzpDdz8%3D' (2026-08-04)
  → 'github:NixOS/nixpkgs/5cca3a89405eb65d2adb43754c2af8dac7b6f2e1?narHash=sha256-kvsnFCG4T5dmUj7BMcmpuPZjZNSjOZfhXUdjiBQG2xk%3D' (2026-08-20)
• Updated input 'dank-greeter':
    'github:AvengeMedia/dank-greeter/f353eafdee856a2e1c6ce87ce551304e8a6ed404?narHash=sha256-9hxIB6McRAsHGlsy4HZIv5FJpfKwlpeuVmPntxj4J8I%3D' (2026-07-30)
  → 'github:AvengeMedia/dank-greeter/e957e4388fb04c30879200a1b58b7d27c9e51f2c?narHash=sha256-yhhFqTRpo6PuSmA2C1S/RwsunJCXLB437PkJXMxJ6gU%3D' (2026-08-21)
• Updated input 'dank-material-shell':
    'github:AvengeMedia/DankMaterialShell/fb9f00a61616456115c2b63128fb51bba93494ee?narHash=sha256-YwKRVAmiUuFCzve8eAf%2B1xNpbOwfSLgadccYZKPyYzw%3D' (2026-08-14)
  → 'github:AvengeMedia/DankMaterialShell/b482e9b89877ef86726804ed9827aba33c5b9cbd?narHash=sha256-DHDTFjVvVNhdFJ6OEspjey8TVpGDcXT0ER8w9Y3Rntg%3D' (2026-08-22)
• Updated input 'dank-material-shell/dank-qml-common':
    'github:AvengeMedia/dank-qml-common/3373281fdba24e030ef47325f9db01494780a4a3?narHash=sha256-61G4G6nQqSV4DWNyZAYlZOLAY6%2BUg%2BJQA1SaifacaSI%3D' (2026-08-13)
  → 'github:AvengeMedia/dank-qml-common/720d75089580f1f3b7a2d6ed4b39e823734ceefa?narHash=sha256-O/TmlR3EvOlKknz6AB8xDeUUCv3sgsIHdejgHJcdlGM%3D' (2026-08-21)
• Updated input 'dcal':
    'github:AvengeMedia/dcal/a57a879061cd482c416d5ece44cb529249c37b06?narHash=sha256-aQOU08ECTd0savQD80AIGG9sqQ41zWHcWZeuUzz39ts%3D' (2026-08-09)
  → 'github:AvengeMedia/dcal/fe61f4e69e2178511711c3ac254539cd6d951a49?narHash=sha256-v1jjjpz9YJQS9zQEpB%2BU8AybBoETdfg41AZTL9L9Y/g%3D' (2026-08-21)
• Updated input 'dms-plugin-registry':
    'github:AvengeMedia/dms-plugin-registry/f1d584f1c3f17203cb544ba65b67de2797cdf070?narHash=sha256-QNZ7c5U4/glM3evnXZEoxx99odM1qWw/N1/6p9C7k9M%3D' (2026-08-15)
  → 'github:AvengeMedia/dms-plugin-registry/b65b029182b781c7d61ecfe1561eaae3fd059554?narHash=sha256-aIgj4qdPOMd1A0npFStI%2Bd5UxLcwuYjIw/kXSPyNZsw%3D' (2026-08-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d4fd24667c8cbef124bb70a20380cab75ec8474d?narHash=sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM%3D' (2026-07-27)
  → 'github:nix-community/home-manager/65258d5c65a250189fde2e35f490d15e064c4c62?narHash=sha256-Sxu1NLTD/Ern6hFGLlZmtKCSct3YQXZI/lls8RE1XeM%3D' (2026-08-22)
• Updated input 'niri-nix':
    'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=01cb364fdb88786c0059fa80a2b539aa3a54e58e' (2026-08-15)
  → 'git+https://codeberg.org/BANanaD3V/niri-nix?ref=refs/heads/main&rev=ecd0e136e75dc37967f5a6a5fea5a99613c503c1' (2026-08-19)
• Updated input 'niri-nix/niri-unstable':
    'github:YaLTeR/niri/606284464d4a99bb35710fee68192bc71085ee7c?narHash=sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY%3D' (2026-08-14)
  → 'github:YaLTeR/niri/e9b215fef4b11ad36776553fb8bd45118ef03b03?narHash=sha256-uJKImwjqQ6Y%2B5b1IN93j6rEKGRoR0CsOuC/7vqluhJM%3D' (2026-08-18)
• Updated input 'niri-nix/nixpkgs':
    'github:nixos/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
  → 'github:nixos/nixpkgs/ec2d622de0773551768cf98f3fc50cbcc003b9c5?narHash=sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo%3D' (2026-08-17)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/5607f78eb46ce192a1fdf2f4f566682e769c7c35?narHash=sha256-9RfAshi6/ou2P2NgiuHNtGGHghzmtpk0Z8uG3CqKa08%3D' (2026-08-15)
  → 'github:fufexan/nix-gaming/5ba87d8c49b6101c5a5715fa3145a71f34c93186?narHash=sha256-2XyURKmhVfr2yXr6T4uBPArikpdDyKZTuYLTIpKpzH4%3D' (2026-08-22)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/70ce234312134a463ba7728e94da2486a1d237ac?narHash=sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU%3D' (2026-08-06)
  → 'github:NixOS/nixpkgs/6b5e5b7a6631f065bf6908986990b37d845f847f?narHash=sha256-smTKQXMLLStzc8zJevMCckbk3My7SvbbLmPYZUJJKW4%3D' (2026-08-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6?narHash=sha256-Y2mSr%2BHLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I%3D' (2026-08-09)
  → 'github:nix-community/nix-index-database/c7962dc97b45129df8d751bedaf37beb5a17706e?narHash=sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA%3D' (2026-08-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/02e08985a27c65ffd33d434eeb2e660a2e4dc84d?narHash=sha256-QvnceIGTBeDvDd9oCn%2BGvdsnkquliuwbVgpiRH68qaQ%3D' (2026-08-14)
  → 'github:NixOS/nixpkgs/5880666fd9eb563038431edb35c2d0aa595884e6?narHash=sha256-OURZPknrTjQrlNyxPdqzyqmU/81Wes1CUP/Ft1Rv/YI%3D' (2026-08-20)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
  → 'github:NixOS/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46?narHash=sha256-RD2kNWCG%2BBjo6h%2BJVjWVNntZs2GtRoeY2xHjts/FNkA%3D' (2026-08-19)
• Updated input 'nur':
    'github:nix-community/NUR/429068755d9b8322e29a6271d4227382acb941a9?narHash=sha256-TfoAjYy4fr47Eux27UKwO899hyPtw7VAgWb9Wqrvkug%3D' (2026-08-15)
  → 'github:nix-community/NUR/5733b00a2d9b7d7035928d0c0e26c0ad4eb2b5af?narHash=sha256-3r8M%2B7PJ98PuXuiPnOVRBGWleZVotH740FzsaXOfBmc%3D' (2026-08-22)
• Updated input 'nvim-config':
    'github:derethil/nvim-config/d4045a166703de18a8c7fa0fe4dcc5e8549fd293?narHash=sha256-FI1Gb%2Bo4hXhd01lNiDKQ51Xh8hq9OgaGF6%2B92ksp9ps%3D' (2026-08-19)
  → 'github:derethil/nvim-config/b75c240ebdfa32b430ea4cc7b101ccecaf8ae69e?narHash=sha256-Loi53INnwUp/WjWJbq32w8xPdFSHmjWK/RBQ0XUsb2U%3D' (2026-08-20)
• Updated input 'paneru':
    'github:karinushka/paneru/d667379b14e3f127efe7d9649b909d8f4a325c41?narHash=sha256-RfaQAA2lMPlBU2Umh386/OyuA4bJRElRwgMAF07HKUk%3D' (2026-08-11)
  → 'github:karinushka/paneru/bcf248ef60aa4c0b49002161b97bc6e268b05aa7?narHash=sha256-rgp2aLduKyyi7dpUzKO9FXszaTM0%2BgyiogPPN6y92yA%3D' (2026-08-19)
• Added input 'paneru/crane':
    'github:ipetkov/crane/508ff4829aefddee8ea62291e86b144b58365724?narHash=sha256-6VCYI5xashcnAR1lambqt9FGh0F6kYhg1P2Z0VDlr48%3D' (2026-07-31)
• Updated input 'paneru/flake-parts':
    'github:hercules-ci/flake-parts/5d82aa3d6b5da25dbfec1a995750a70a03b8c659?narHash=sha256-tTEOTTjMHd8Vffn4hehLTPgOXXxJ27xfkf4DoyZgD7s%3D' (2026-05-04)
  → 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e?narHash=sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w%2B6NWK9yA%3D' (2026-07-01)
• Updated input 'paneru/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255737b94216eb71cce308e2912cf6bc2d7c?narHash=sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC%2BeBu2zKlp8%3D' (2026-06-28)
• Updated input 'paneru/import-tree':
    'github:vic/import-tree/c41e7d58045f9057880b0d85e1152d6a4430dbf1?narHash=sha256-BtZ2dtkBdSUnFPPFc%2Bn0kcMbgaTxzFNPv2iaO326Ffg%3D' (2026-03-16)
  → 'github:vic/import-tree/4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69?narHash=sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8%3D' (2026-07-17)
• Updated input 'paneru/nix-darwin':
    'github:nix-darwin/nix-darwin/8c62fba0854ba15c8917aed18894dbccb48a3777?narHash=sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE%3D' (2026-05-03)
  → 'github:nix-darwin/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04?narHash=sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU%3D' (2026-07-30)
• Updated input 'quickshell':
    'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=28771c7c74b42e20afca0b1b63980cb46515537c' (2026-08-02)
  → 'git+https://github.com/quickshell-mirror/quickshell?ref=master&rev=1a4716cde794a59928d9d9fc15f2afc7a95de360' (2026-08-21)```